### PR TITLE
Set up ESLint Promise plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,13 @@
+import { join } from 'node:path'
 import neostandard from 'neostandard'
+import { includeIgnoreFile } from '@eslint/compat'
 import eslintConfigPrettier from 'eslint-config-prettier/flat'
 import pluginPromise from 'eslint-plugin-promise'
 
+const gitignorePath = join(import.meta.dirname, '.gitignore')
+
 export default [
+  includeIgnoreFile(gitignorePath, 'Imported .gitignore patterns'),
   ...neostandard({
     noStyle: true
   }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
         "@11ty/eleventy-img": "^6.0.4",
+        "@eslint/compat": "^1.3.1",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.21",
@@ -441,6 +442,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.3.1.tgz",
+      "integrity": "sha512-k8MHony59I5EPic6EQTCNOuPoVBnoYXkP+20xvwFjN7t0qI3ImyvyBgg+hIVPwC8JaxVjjUZld+cLfBLFDLucg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-img": "^6.0.4",
+    "@eslint/compat": "^1.3.1",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
Sets up [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise) and its recommended configuration so we can use best practices when working with Promises.

Also adds the `_site` folder (and other files ignore by Git) to the files ignored by ESLint as we don't need to lint files that are not commited to the repository.