### PR TITLE
Add sitemap generation

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,5 +1,11 @@
 export default function () {
   return {
+    // The absolute URL of the site
+    url:
+      process.env.CONTEXT === 'production'
+        ? process.env.URL
+        : process.env.DEPLOY_PRIME_URL,
+
     env: {
       // Netlify deploy context
       // Possible values: "dev", "branch-deploy", "deploy-preview", "production"

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for page in collections.all %}
+  <url>
+    <loc>{{ site.url }}{{ page.url | url }}</loc>
+    <lastmod>{{ page.date.toISOString() }}</lastmod>
+  </url>
+{%- endfor %}
+</urlset>


### PR DESCRIPTION
Adds generation of a `sitemap.xml` file based on the available pages.

> [!NOTE]
> In production, this is reliant on the presence of an absolute URL in the `_data/site.js` file. We don't know what that will be yet, so it's currently a placeholder value. 

This uses two pieces of front-matter that affect how pages appear in the sitemap:

* `date` – A manually provided date for when the content was last updated. If unspecified, it uses the last modified date of the source file. 
* `eleventyExcludeFromCollections` – If `true`, the page will not appear in the sitemap (or any other place that uses Eleventy collections). 

## Changes
- Add Nunjucks file to generate a `sitemap.xml` file from the `all` Eleventy collection.
- Add `site.url` option to global data.

## Thoughts
I initially added support for the `changefreq` and `priority` options, but it seems that most major search engines (or Google and Bing, at least) ignore or de-prioritise those options, so I ended up removing them for being superfluous. 