### PR TITLE
Prevent indexing of pages when not in production

### DIFF
--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -6,6 +6,10 @@
 
 {% block head %}
   {{ super() }}
+  {#- Prevent search engine indexing for archive, preview and development builds -#}
+  {% if site.env.CONTEXT !== "production" %}
+    <meta name="robots" content="noindex, nofollow">
+  {% endif %}
   <link rel="stylesheet" href="{{ '/assets/stylesheet.css' | url }}">
 {% endblock %}
 


### PR DESCRIPTION
Our preview deployment shouldn't be indexed by search engines so we're adding the adequate `<meta name="robots">` tag to the head when not in production.