### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 15
+
+    # Group packages into shared PR
+    groups:
+      eleventy:
+        patterns:
+          - '@11ty/*'
+
+      css:
+        patterns:
+          - 'sass'
+          - 'autoprefixer'
+          - 'cssnano'
+          - 'cssnano-*'
+          - 'postcss'
+          - 'postcss-*'
+
+      javascript:
+        patterns:
+          - '@babel/*'
+          - '@rollup/*'
+          - 'rollup'
+          - 'rollup-*'
+
+      lint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - 'neostandard'
+          - 'prettier'
+          - 'stylelint'
+          - 'stylelint-*'
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: monthly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+      # Include indirect browser data updates
+      # https://caniuse.com
+      - dependency-name: caniuse-lite
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: monthly
+      time: '10:30'
+      timezone: 'Europe/London'


### PR DESCRIPTION
- Update both npm packages and GitHub actions
- Use the same schedule (first day of the month) as our other repositories
- Use the same limit (15) of pull requests as our other repositories
- Sets up groups of dependencies to have fewer pull requests
  - eleventy
  - css build dependencies
  - javascript build dependencies
  - linting