### PR TITLE
Only lint committed SCSS files pre-commit

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,7 +4,7 @@ export default {
     'npm run lint:prettier:cli -- --write'
   ],
   '*.scss': [
-    'npm run lint:scss -- --fix',
+    'npm run lint:scss:cli -- --fix',
     'npm run lint:prettier:cli -- --write'
   ],
   '*.md': ['npm run lint:prettier:cli -- --write'],


### PR DESCRIPTION
While working on #42 , I noticed our pre-commit hook was linting all SCSS files in the repository, but we only need to lint the ones being commited. So this little PR addresses that. 