### PR TITLE
[SPIKE] Add in-page tables of contents

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -3,7 +3,7 @@ import { setupStylesheetCompilation } from './eleventy/stylesheets.js'
 import { setupJavaScriptCompilation } from './eleventy/javascript.js'
 import { setupMarkdownCompilation } from './eleventy/markdown.js'
 import { setupMedia } from './eleventy/media.js'
-import { setupNavigation } from './eleventy/navigation.js'
+import { setupNavigation, tableOfContents } from './eleventy/navigation.js'
 import { setupShortcodes } from './eleventy/shortcodes.js'
 
 /**
@@ -36,6 +36,7 @@ export default function (eleventyConfig) {
 
   // Set up data to help compute navigation
   eleventyConfig.addPlugin(setupNavigation)
+  eleventyConfig.addPlugin(tableOfContents)
 
   // Import custom shortcodes
   eleventyConfig.addPlugin(setupShortcodes)

--- a/eleventy/markdown.js
+++ b/eleventy/markdown.js
@@ -1,4 +1,5 @@
 import markdownIt from 'markdown-it'
+import markdownItAnchor from 'markdown-it-anchor'
 import markdownItGovuk from 'markdown-it-govuk'
 
 /**
@@ -8,7 +9,9 @@ export function setupMarkdownCompilation(eleventyConfig) {
   const markdownConfig = markdownIt({
     html: true,
     typographer: true
-  }).use(markdownItGovuk)
+  })
+    .use(markdownItGovuk)
+    .use(markdownItAnchor)
 
   /**
    * Process a string as Markdown, treating it as a block of content (i.e. it will

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "linkinator": "^6.1.4",
         "lint-staged": "^16.1.2",
         "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^9.2.0",
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
         "nodemon": "^3.1.10",
@@ -4010,6 +4011,34 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -9653,6 +9682,17 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+      "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it-govuk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
+        "node-html-parser": "^7.0.1",
         "nodemon": "^3.1.10",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
@@ -7939,6 +7940,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -10061,6 +10072,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "linkinator": "^6.1.4",
     "lint-staged": "^16.1.2",
     "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "^9.2.0",
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
     "nodemon": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
     "nodemon": "^3.1.10",
+    "node-html-parser": "^7.0.1",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "postcss": "^8.5.6",

--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -84,6 +84,20 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{title}}</h1>
+
+  {# In-page table of contents #}
+  {%- set headingList = getTableOfContents(content) %}
+  {%- if headingList | length > 0 %}
+    <h2 class="govuk-heading-s">On this page</h2>
+    <ul class="govuk-list">
+      {%- for heading in headingList %}
+      <li>
+        <a class="govuk-link" href="#{{ heading.id }}">{{ heading.html | safe }}</a>
+      </li>
+      {%- endfor %}
+    </ul>
+  {%- endif %}
+
   {{ content | safe }}
 
   {# Render the list of pages under each chapter after the content


### PR DESCRIPTION
Add the means to have in-page tables of contents.

## Changes
- Installed and configured the [markdown-it-anchors](https://www.npmjs.com/package/markdown-it-anchor) plugin. This automatically adds `id`s to heading elements (`h1`–`h6`) in Markdown-parsed content.
- Added a new function to parse the HTML of a page's content and extract headings.
  - This currently only grabs `h2` elements that have an `id` attribute, though it can do multiple heading levels and keep track of how they're nested.
  - This is exposed as a Nunjucks global function named `getTableOfContents`. This doesn't use Eleventy's generic shortcode and filter tooling, as global functions are a feature specific to Nunjucks.
- Updated the generic template to include a table of contents below the page title (`h1`).

## Thoughts

There are other markdown-it packages that can generate table of content lists, such as [markdown-it-toc-done-right](https://www.npmjs.com/package/markdown-it-toc-done-right). I opted to roll our own here because:

1. you don't get fine-grained control over the output HTML from any of these plugins that I've seen, just the ability to configure a few classes here and there; and 
2. it being a markdown-it plugin means that we would have to place the ToC somewhere that the markdown parser can reach it, which limits how we could use it.