### PR TITLE
Improve handling of media

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -37,6 +37,12 @@ export default function (eleventyConfig) {
   // Copy `mp4` files in the output site
   eleventyConfig.addPassthroughCopy('**/*.mp4')
 
+  // Eleventy doesn't watch the plugins the configuration
+  // depends on, so we need to give it a little nudge
+  eleventyConfig.addWatchTarget('./eleventy/**', {
+    resetConfig: true
+  })
+
   eleventyConfig.addPlugin(setupNunjucks)
 
   // Watch and compile Sass files on change

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -34,6 +34,9 @@ export default function (eleventyConfig) {
     }
   })
 
+  // Copy `mp4` files in the output site
+  eleventyConfig.addPassthroughCopy('**/*.mp4')
+
   eleventyConfig.addPlugin(setupNunjucks)
 
   // Watch and compile Sass files on change

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,47 +1,21 @@
-import { eleventyImageTransformPlugin } from '@11ty/eleventy-img'
-
 import { setupNunjucks } from './eleventy/nunjucks.js'
 import { setupStylesheetCompilation } from './eleventy/stylesheets.js'
 import { setupJavaScriptCompilation } from './eleventy/javascript.js'
 import { setupMarkdownCompilation } from './eleventy/markdown.js'
 import { setupNavigation } from './eleventy/navigation.js'
+import { setupMedia } from './eleventy/media.js'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
  */
 export default function (eleventyConfig) {
-  // Load Eleventy image plugin. In this configuration, it automatically
-  // resizes and compresses the sources of <img>s referenced in output HTML
-  eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
-    // Output image formats
-    formats: ['svg', 'avif', 'webp'],
-
-    // If the input is SVG, only output SVG
-    svgShortCircuit: true,
-
-    // Output image widths
-    // These represent full-width, two-thirds and one-third grid widths respectively
-    widths: [960, 630, 300],
-
-    // Attributes on the output HTML
-    htmlOptions: {
-      imgAttributes: {
-        class: 'app-prose-image',
-        loading: 'lazy',
-        decoding: 'async'
-      },
-      pictureAttributes: {}
-    }
-  })
-
-  // Copy `mp4` files in the output site
-  eleventyConfig.addPassthroughCopy('**/*.mp4')
-
   // Eleventy doesn't watch the plugins the configuration
   // depends on, so we need to give it a little nudge
   eleventyConfig.addWatchTarget('./eleventy/**', {
     resetConfig: true
   })
+
+  eleventyConfig.addPlugin(setupMedia)
 
   eleventyConfig.addPlugin(setupNunjucks)
 

--- a/eleventy/media.js
+++ b/eleventy/media.js
@@ -27,6 +27,14 @@ export function setupMedia(eleventyConfig) {
         decoding: 'async'
       },
       pictureAttributes: {}
+    },
+
+    // Sharp does not handle GIFs by default and limits
+    // the size of the images it can process (which we lift
+    // to be more open )
+    sharpOptions: {
+      animated: true,
+      limitInputPixels: false
     }
   })
 

--- a/eleventy/media.js
+++ b/eleventy/media.js
@@ -1,0 +1,35 @@
+import { eleventyImageTransformPlugin } from '@11ty/eleventy-img'
+
+/**
+ * Configures processing of media (images, videos)
+ *
+ * @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
+ */
+export function setupMedia(eleventyConfig) {
+  // Load Eleventy image plugin. In this configuration, it automatically
+  // resizes and compresses the sources of <img>s referenced in output HTML
+  eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
+    // Output image formats
+    formats: ['svg', 'avif', 'webp'],
+
+    // If the input is SVG, only output SVG
+    svgShortCircuit: true,
+
+    // Output image widths
+    // These represent full-width, two-thirds and one-third grid widths respectively
+    widths: [960, 630, 300],
+
+    // Attributes on the output HTML
+    htmlOptions: {
+      imgAttributes: {
+        class: 'app-prose-image',
+        loading: 'lazy',
+        decoding: 'async'
+      },
+      pictureAttributes: {}
+    }
+  })
+
+  // Copy `mp4` files in the output site
+  eleventyConfig.addPassthroughCopy('**/*.mp4')
+}

--- a/eleventy/media.js
+++ b/eleventy/media.js
@@ -10,7 +10,7 @@ export function setupMedia(eleventyConfig) {
   // resizes and compresses the sources of <img>s referenced in output HTML
   eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
     // Output image formats
-    formats: ['svg', 'avif', 'webp'],
+    formats: ['auto', 'avif', 'webp'],
 
     // If the input is SVG, only output SVG
     svgShortCircuit: true,


### PR DESCRIPTION
Ensures MP4 assets are copied and that sharp (the image processor used by Eleventy Image) can handle GIFs and large files (as that's all we have a the moment for some of the animations).

As we are starting to have a little bit of configuration around media, I took the liberty to move the configuration in a specific Eleventy Plugin (and make the config reload when our own plugins are changed).