### PR TITLE
Remove run of Prettier when committing SVGs

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -9,5 +9,5 @@ export default {
   ],
   '*.md': ['npm run lint:prettier:cli -- --write'],
   '*.{yaml,yml}': ['npm run lint:prettier:cli -- --write'],
-  '*.svg': ['npm run lint:svg:cli', 'npm run lint:prettier:cli -- --write']
+  '*.svg': ['npm run lint:svg:cli']
 }


### PR DESCRIPTION
Turns out Prettier does not support formatting SVGs: https://github.com/prettier/prettier/issues/5322.

One this we could do is run [SVGO](https://svgo.dev/), but that's only worth if Eleventy Image doesn't already run it. We'd likely want to have an ignore list if we enable automatic processing of SVGs in case some SVGs are problematic.