### PR TITLE
Abstract handling of whitespace in shortcodes

### DIFF
--- a/eleventy/shortcodes/grid.js
+++ b/eleventy/shortcodes/grid.js
@@ -1,5 +1,4 @@
-import { markdown } from '../markdown.js'
-import { trimTemplateLiteral } from '../utils.js'
+import { outdent } from 'outdent'
 
 export function grid(content, options = {}) {
   const defaultOptions = {
@@ -24,7 +23,33 @@ export function grid(content, options = {}) {
     cssProperties.push(`--app-grid-min-width: ${options.minWidth}`)
   }
 
-  return trimTemplateLiteral(`<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join('')}">
-    ${markdown(content)}
-  </div>`)
+  // For content to be formatted properly inside the `<div>`
+  // we need two things to happen for markdown to be processed properly:
+  // 1. Removing any indentation, so that markdown blocks are properly at the start of the line
+  // 2. Adding new lines at the start and end, unless it's an HTML element
+  const formattedContent = ensureLeadingTrailingNewLines(
+    outdent.string(content)
+  )
+
+  return `\n\n<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join(';')}">${formattedContent}</div>\n\n`
+}
+
+function ensureLeadingTrailingNewLines(content) {
+  content = content.trim()
+  if (!startsWithHTML(content)) {
+    content = `\n\n${content}`
+  }
+  if (!endsWithHTML(content)) {
+    content = `${content}\n\n`
+  }
+
+  return content
+}
+
+function startsWithHTML(string) {
+  return string.match(/^<\[\w][\w-]?>/)
+}
+
+function endsWithHTML(string) {
+  return string.match(/<\/[\w]+[\w-]?>$/)
 }

--- a/eleventy/shortcodes/grid.js
+++ b/eleventy/shortcodes/grid.js
@@ -1,6 +1,6 @@
-import { outdent } from 'outdent'
+import { blockShortcode } from './util.js'
 
-export function grid(content, options = {}) {
+export const grid = blockShortcode((content, options = {}) => {
   const defaultOptions = {
     classes: undefined,
 
@@ -23,33 +23,5 @@ export function grid(content, options = {}) {
     cssProperties.push(`--app-grid-min-width: ${options.minWidth}`)
   }
 
-  // For content to be formatted properly inside the `<div>`
-  // we need two things to happen for markdown to be processed properly:
-  // 1. Removing any indentation, so that markdown blocks are properly at the start of the line
-  // 2. Adding new lines at the start and end, unless it's an HTML element
-  const formattedContent = ensureLeadingTrailingNewLines(
-    outdent.string(content)
-  )
-
-  return `\n\n<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join(';')}">${formattedContent}</div>\n\n`
-}
-
-function ensureLeadingTrailingNewLines(content) {
-  content = content.trim()
-  if (!startsWithHTML(content)) {
-    content = `\n\n${content}`
-  }
-  if (!endsWithHTML(content)) {
-    content = `${content}\n\n`
-  }
-
-  return content
-}
-
-function startsWithHTML(string) {
-  return string.match(/^<\[\w][\w-]?>/)
-}
-
-function endsWithHTML(string) {
-  return string.match(/<\/[\w]+[\w-]?>$/)
-}
+  return `<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join(';')}">${content}</div>`
+})

--- a/eleventy/shortcodes/util.js
+++ b/eleventy/shortcodes/util.js
@@ -1,0 +1,46 @@
+import { outdent } from 'outdent'
+
+/**
+ * Wraps a shortcode function so it handles whitespace correctly
+ * both inside and outside the shortcode tags
+ *
+ * Allows shortcodes to receive both markdown and HTML
+ *
+ * @param {(content:string, options:Object) => string} shortcode
+ * @returns
+ */
+export function blockShortcode(shortcode) {
+  return function (content, options) {
+    // For content to be formatted properly inside the `<div>`
+    // we need two things to happen for markdown to be processed properly:
+    // 1. Removing any indentation, so that markdown blocks are properly at the start of the line
+    // 2. Adding new lines at the start and end, unless it's an HTML element
+    const formattedContent = ensureLeadingTrailingNewLines(
+      outdent.string(content)
+    )
+
+    const output = shortcode(formattedContent, options)
+
+    return `\n\n${output}\n\n`
+  }
+}
+
+function ensureLeadingTrailingNewLines(content) {
+  content = content.trim()
+  if (!startsWithHTML(content)) {
+    content = `\n\n${content}`
+  }
+  if (!endsWithHTML(content)) {
+    content = `${content}\n\n`
+  }
+
+  return content
+}
+
+function startsWithHTML(string) {
+  return string.match(/^<\[\w][\w-]?>/)
+}
+
+function endsWithHTML(string) {
+  return string.match(/<\/[\w]+[\w-]?>$/)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
         "nunjucks": "^3.2.4",
+        "outdent": "^0.8.0",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
@@ -9208,6 +9209,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
     "nunjucks": "^3.2.4",
+    "outdent": "^0.8.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",

--- a/src/_tests/grid/whitespace.md
+++ b/src/_tests/grid/whitespace.md
@@ -1,0 +1,273 @@
+---
+title: Test page for the `grid` shortcode
+---
+
+<!-- prettier-ignore-start -->
+<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
+<style>
+    .app-grid {
+        outline: dashed 2px grey;
+
+        > * {
+            outline: solid
+        }
+    }
+</style>
+
+## `content`
+
+### Single line
+
+{% grid %}Hello{% endgrid %}
+
+### Next line both ends
+
+{% grid %}
+Grid content
+{% endgrid %}
+
+### Line break
+
+{% grid %}
+
+Grid content
+
+{% endgrid %}
+
+### Intended
+
+{% grid %}
+    Grid content
+{% endgrid %}
+
+### Same line at start
+{% grid %}Grid content
+{% endgrid %}
+
+### Next line at start
+{% grid %}
+Grid content{% endgrid %}
+
+### Markdown
+
+#### Next line both ends
+
+{% grid %}
+A paragraph introducing:
+
+- a list
+{% endgrid %}
+
+#### Line break at start, line break at end
+
+It shouldn't have extra `<p>` from markdown transformation
+
+{% grid %}
+
+A paragraph introducing:
+
+- a list
+
+{% endgrid %}
+
+#### Indented
+
+It shouldn't be turned into a Markdown code block
+
+{% grid %}
+    A paragraph introducing:
+
+    - a list
+{% endgrid %}
+
+#### Same line at start
+
+{% grid %}A paragraph introducing:
+
+    - a list
+{% endgrid %}
+
+#### Same line at end
+
+{% grid %}
+    A paragraph introducing:
+
+    - a list{% endgrid %}
+
+### HTML
+
+#### Next line both ends
+
+{% grid %}
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+{% endgrid %}
+
+#### Line break at start, line break at end
+
+It shouldn't have extra `<p>` from Markdown transformation
+
+{% grid %}
+
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+
+{% endgrid %}
+
+#### Indented
+
+It shouldn't be turned into a Markdown code block
+
+{% grid %}
+
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+
+{% endgrid %}
+
+#### Same line at start
+
+{% grid %}<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+{% endgrid %}
+
+#### Same line at end
+
+{% grid %}
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>{% endgrid %}
+
+#### Pre-formatted text
+
+{% grid %}
+<pre>
+Hello,
+    How does this look?
+  Some space indentation as well
+</pre>
+{% endgrid %}
+
+#### Mixed with markdown
+
+##### Markdown first
+
+{% grid %}
+- a list
+- with two items
+
+<small>Followed by some HTML</small>
+{% endgrid %}
+
+##### Markdown last
+
+{% grid %}
+<small>Some HTML...</small>
+
+- a list
+- with two items
+{% endgrid %}
+
+##### Markdown around
+
+{% grid %}
+1. One
+2. Two
+
+<small>Some HTML...</small>
+
+- a list
+- with two items
+{% endgrid %}
+
+##### HTML around
+
+{% grid %}
+<small>Some initial HTML...</small>
+
+- a list
+- another list
+
+<small>HTML again</small>
+{% endgrid %}
+
+##### Markdown inside
+
+Like with any nesting of Markdown inside HTML,
+the markdown blocks need to be at the start of the line
+
+{% grid %}
+<article>
+
+###### Here's the heading
+
+And some content
+
+</article>
+{% endgrid %}
+
+Markdown blocks (headings, lists...) won't get detected if they're not at the start of the line,
+only `<p>` tags will be created
+
+{% grid %}
+<article>
+
+    ###### Here's the heading
+
+    And some content
+
+</article>
+{% endgrid %}
+
+Without a line break after the HTML opening tag, Markdown won't be detected either
+
+{% grid %}
+<article>
+Some **bold text**
+###### Here's the heading
+
+And some content, including **bold text**
+</article>
+{% endgrid %}
+
+## Surrounding content
+
+It should correctly compile the markdown before
+and after the shortcode
+
+### On different line than previous and following content
+Content before
+{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+### Same line before
+
+Content before{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+### Same line after
+
+Content before
+{% grid %}
+Grid content
+{% endgrid %}Content after
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Builds on the existing `grid` shortcode to abstract the handling of whitespace inside and outside the shortcode.

More details to come