### PR TITLE
Add `grid` shortcode

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,8 +2,9 @@ import { setupNunjucks } from './eleventy/nunjucks.js'
 import { setupStylesheetCompilation } from './eleventy/stylesheets.js'
 import { setupJavaScriptCompilation } from './eleventy/javascript.js'
 import { setupMarkdownCompilation } from './eleventy/markdown.js'
-import { setupNavigation } from './eleventy/navigation.js'
 import { setupMedia } from './eleventy/media.js'
+import { setupNavigation } from './eleventy/navigation.js'
+import { setupShortcodes } from './eleventy/shortcodes.js'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
@@ -36,6 +37,11 @@ export default function (eleventyConfig) {
   // Set up data to help compute navigation
   eleventyConfig.addPlugin(setupNavigation)
 
+  // Import custom shortcodes
+  eleventyConfig.addPlugin(setupShortcodes)
+
+  // Set the default layout for new pages
+  // Can be overridden using `layout` front-matter parameter
   eleventyConfig.addGlobalData('layout', 'generic')
 
   return {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -44,6 +44,10 @@ export default function (eleventyConfig) {
   // Can be overridden using `layout` front-matter parameter
   eleventyConfig.addGlobalData('layout', 'generic')
 
+  // Set up bundle for per-page CSS
+  // https://www.11ty.dev/docs/plugins/bundle/
+  eleventyConfig.addBundle("css")
+
   return {
     markdownTemplateEngine: 'njk',
     dir: {

--- a/eleventy/shortcodes.js
+++ b/eleventy/shortcodes.js
@@ -1,0 +1,21 @@
+import { grid } from './shortcodes/grid.js'
+
+/**
+ *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
+ */
+export function setupShortcodes(eleventyConfig) {
+  // Standalone shortcodes are a single tag, they're passed parameters like a
+  // function is normally.
+  //
+  // {% image(param1, param2) %}
+  // function image(param1, param2)
+
+  // Paired shortcodes require a starting and ending tag. Any content between
+  // those tags is passed as the first parameter.
+  //
+  // For example:
+  // {% grid(param1, param2) %} Content {% endgrid %}
+  //
+  // function grid(content, param1, param2)
+  eleventyConfig.addPairedShortcode('grid', grid)
+}

--- a/eleventy/shortcodes/grid.js
+++ b/eleventy/shortcodes/grid.js
@@ -1,0 +1,35 @@
+export function grid(content, options = {}) {
+  const defaultOptions = {
+    classes: undefined,
+
+    // The number of columns to use
+    columns: undefined
+  }
+  options = { ...defaultOptions, ...options }
+
+  // Assemble custom properties
+  const cssProperties = []
+  if (typeof options.columns === 'number') {
+    cssProperties.push(`--app-grid-columns-mobile: ${options.columns}`)
+  } else if (typeof options.columns === 'object') {
+    if (options.columns.mobile) {
+      cssProperties.push(
+        `--app-grid-columns-mobile: ${options.columns.mobile}`
+      )
+    }
+    if (options.columns.tablet) {
+      cssProperties.push(
+        `--app-grid-columns-tablet: ${options.columns.tablet}`
+      )
+    }
+    if (options.columns.desktop) {
+      cssProperties.push(
+        `--app-grid-columns-desktop: ${options.columns.desktop}`
+      )
+    }
+  }
+
+  return `<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join(';')}">
+    ${content}
+  </div>`
+}

--- a/eleventy/shortcodes/grid.js
+++ b/eleventy/shortcodes/grid.js
@@ -1,4 +1,6 @@
-export function grid(content, options = {}) {
+import { blockShortcode } from './utils.js'
+
+export const grid = blockShortcode((content, options = {}) => {
   const defaultOptions = {
     classes: undefined,
 
@@ -32,4 +34,4 @@ export function grid(content, options = {}) {
   return `<div class="app-grid${options.classes ? ` ${options.classes}` : ''}" style="${cssProperties.join(';')}">
     ${content}
   </div>`
-}
+})

--- a/eleventy/shortcodes/utils.js
+++ b/eleventy/shortcodes/utils.js
@@ -1,0 +1,54 @@
+import { outdent } from 'outdent'
+
+/**
+ * Wraps a shortcode function so it handles whitespace correctly
+ * both inside and outside the shortcode tags
+ *
+ * Allows shortcodes to receive both markdown and HTML
+ *
+ * @param {(content:string, options:Object) => string} shortcode
+ * @returns
+ */
+export function blockShortcode(shortcode) {
+  return function (content, {insideHTML, indent = 0, ...options} = {}) {
+    // For content to be formatted properly inside the `<div>`
+    // we need two things to happen for markdown to be processed properly:
+    // 1. Removing any indentation, so that markdown blocks are properly at the start of the line
+    // 2. Adding new lines at the start and end, unless it's an HTML element
+    const formattedContent = ensureLeadingTrailingNewLines(
+      outdent.string(content)
+    )
+
+    const output = indentLines(shortcode(formattedContent, options), {amount: indent})
+
+    return insideHTML ? output : `\n\n${output}\n\n`
+  }
+}
+
+function indentLines(content, {amount = 0, character = ' '}) {
+  const indentation = character.repeat(amount);
+
+  return content.split('\n')
+    .map(line => indentation + line)
+    .join('\n')
+}
+
+function ensureLeadingTrailingNewLines(content) {
+  content = content.trim()
+  if (!startsWithHTML(content)) {
+    content = `\n\n${content}`
+  }
+  if (!endsWithHTML(content)) {
+    content = `${content}\n\n`
+  }
+
+  return content
+}
+
+function startsWithHTML(string) {
+  return string.match(/^<\[\w][\w-]?>/)
+}
+
+function endsWithHTML(string) {
+  return string.match(/<\/[\w]+[\w-]?>$/)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
         "nunjucks": "^3.2.4",
+        "outdent": "^0.8.0",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
@@ -9954,6 +9955,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
     "nunjucks": "^3.2.4",
+    "outdent": "^0.8.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",

--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -11,6 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
   {% endif %}
   <link rel="stylesheet" href="{{ '/assets/stylesheet.css' | url }}">
+  {% getBundle "css" %}
 {% endblock %}
 
 {% block header %}

--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -7,7 +7,7 @@
 {% block head %}
   {{ super() }}
   {#- Prevent search engine indexing for archive, preview and development builds -#}
-  {% if site.env.CONTEXT !== "production" %}
+  {% if site.env.CONTEXT !== "production" or metadata.noRobots %}
     <meta name="robots" content="noindex, nofollow">
   {% endif %}
   <link rel="stylesheet" href="{{ '/assets/stylesheet.css' | url }}">

--- a/src/_stylesheets/_grid.scss
+++ b/src/_stylesheets/_grid.scss
@@ -5,7 +5,6 @@
   display: grid;
   grid-template-columns: repeat(var(--app-grid-columns-mobile), 1fr);
   gap: var(--app-grid-gap);
-  align-items: end;
 
   @include govuk-media-query($from: tablet) {
     --app-grid-columns-tablet: var(--app-grid-columns-mobile);

--- a/src/_stylesheets/_grid.scss
+++ b/src/_stylesheets/_grid.scss
@@ -1,0 +1,19 @@
+.app-grid {
+  --app-grid-columns-mobile: 1;
+  --app-grid-gap: #{$govuk-gutter};
+
+  display: grid;
+  grid-template-columns: repeat(var(--app-grid-columns-mobile), 1fr);
+  gap: var(--app-grid-gap);
+  align-items: end;
+
+  @include govuk-media-query($from: tablet) {
+    --app-grid-columns-tablet: var(--app-grid-columns-mobile);
+    grid-template-columns: repeat(var(--app-grid-columns-tablet), 1fr);
+  }
+
+  @include govuk-media-query($from: desktop) {
+    --app-grid-columns-desktop: var(--app-grid-columns-tablet);
+    grid-template-columns: repeat(var(--app-grid-columns-desktop), 1fr);
+  }
+}

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -14,6 +14,8 @@
 @import 'govuk/components/service-navigation';
 @import 'govuk/components/skip-link';
 
+@import 'grid';
+
 @import 'govuk/utilities';
 @import 'govuk/overrides';
 

--- a/src/_tests/_tests.11tydata.js
+++ b/src/_tests/_tests.11tydata.js
@@ -1,0 +1,12 @@
+export default function () {
+  return {
+    // Don't include pages in this directory in Eleventy collections
+    // Prevents it being included in sitemap, global navigation, etc.
+    eleventyExcludeFromCollections: true,
+
+    // Set robots meta tag to `noindex, nofollow` on these pages in production
+    metadata: {
+      noRobots: true
+    }
+  }
+}

--- a/src/_tests/grid/index.md
+++ b/src/_tests/grid/index.md
@@ -2,6 +2,20 @@
 title: Test page for the `grid` shortcode
 ---
 
+{% css %}
+
+<style>
+    .app-grid {
+        outline: dashed 2px grey;
+    
+        > * {
+            outline: solid
+        }
+    }
+</style>
+
+{% endcss %}
+
 ## No configuration
 
 1 column across all breakpoints.

--- a/src/_tests/grid/index.md
+++ b/src/_tests/grid/index.md
@@ -1,0 +1,93 @@
+---
+title: Test page for the `grid` shortcode
+---
+
+## No configuration
+
+1 column across all breakpoints.
+
+{% grid %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+## `columns` parameter
+
+### Mobile configuration only
+
+2 columns on mobile, which is inherited by tablet and desktop.
+
+{% grid { columns: { mobile: 2 } } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+#### Alternate syntax
+
+Number of columns passed as a number instead of an object.
+
+2 columns on mobile, which is inherited by tablet and desktop.
+
+{% grid { columns: 2 } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+### Tablet configuration only
+
+1 column on mobile. 2 columns on tablet, which is inherited by desktop.
+
+{% grid { columns: { tablet: 2 } } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+### Desktop configuration only
+
+1 column on mobile and tablet. 2 columns on desktop.
+
+{% grid { columns: { desktop: 2 } } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+### Hybrid configuration
+
+2 columns on mobile and 4 columns on desktop. Tablet inherits from mobile.
+
+{% grid { columns: { mobile: 2, desktop: 4 } } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+### All sizes configured
+
+2 columns on mobile, 3 on tablet, 4 on desktop.
+
+{% grid { columns: { mobile: 2, tablet: 3, desktop: 4 } } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}
+
+## `classes` parameter
+
+{% grid { columns: 2, classes: "page-custom-grid" } %}
+<div>1</div>
+<div>2</div>
+<div>3</div>
+<div>4</div>
+{% endgrid %}

--- a/src/_tests/grid/whitespace-around.md
+++ b/src/_tests/grid/whitespace-around.md
@@ -1,0 +1,142 @@
+---
+title: Test page for the `grid` shortcode
+---
+
+<!-- prettier-ignore-start -->
+<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
+<style>
+    .app-grid {
+        outline: dashed 2px grey;
+
+        > * {
+            outline: solid
+        }
+    }
+</style>
+
+## Surrounding content
+
+It should correctly compile the markdown before and after the shortcode
+
+### Markdown
+
+#### On different line than previous and following content
+
+Content before
+{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+### Within markdown block
+
+- First item
+    {% grid {indent: 2} %}
+    Grid content
+    {% endgrid %}
+- Second item
+
+#### Line break before and after
+
+Content before
+
+{% grid %}
+Grid content
+{% endgrid %}
+
+Content after
+
+
+#### Same line before
+
+Content before{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+#### Same line after
+
+Content before
+{% grid %}
+Grid content
+{% endgrid %}Content after
+
+
+### HTML
+
+#### Tags before and after
+
+<p class="govuk-body">Content before</p>
+{% grid %}
+Grid content
+{% endgrid %}
+<p class="govuk-body">Content after</p>
+
+#### Tags before and after, with line breaks
+
+Shouldn't add extra paragraphs when Markdown is processed
+
+<p class="govuk-body">Content before</p>
+
+{% grid %}
+Grid content
+{% endgrid %}
+
+<p class="govuk-body">Content after</p>
+
+#### At start of tag
+
+<article>
+{% grid %}
+Grid content
+{% endgrid %}
+</article>
+
+#### With surrounding text inside tag
+
+<article>
+Content before
+{% grid {insideHTML: true} %}
+Grid content
+{% endgrid %}
+Content after
+</article>
+
+### With surrounding inline HTML elements inside tag
+
+<article>
+<span>Content before</span>
+{% grid {insideHTML: true} %}
+Grid content
+{% endgrid %}
+<span>Content after</span>
+</article>
+
+### With surrounding block HTML elements inside tag
+
+<article>
+<ul><li>Content before</ul>
+{% grid %}
+Grid content
+{% endgrid %}
+<ul><li>Content after</ul>
+</article>
+
+### Markdown before, HTML after
+
+- A list before
+{% grid %}
+Grid content
+{% endgrid %}
+<ul><li>Content after</ul>
+
+### HTML before, Markdown after
+
+<ul><li>Content before</ul>
+{% grid %}
+Grid content
+{% endgrid %}
+- A list after
+
+
+<!-- prettier-ignore-end -->

--- a/src/_tests/grid/whitespace-around.md
+++ b/src/_tests/grid/whitespace-around.md
@@ -2,17 +2,22 @@
 title: Whitespace handling around the `grid` shortcode
 ---
 
-<!-- prettier-ignore-start -->
-<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
+{% css %}
+
 <style>
     .app-grid {
         outline: dashed 2px grey;
-
+    
         > * {
             outline: solid
         }
     }
 </style>
+
+{% endcss %}
+
+<!-- prettier-ignore-start -->
+<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
 
 ## Surrounding content
 

--- a/src/_tests/grid/whitespace-around.md
+++ b/src/_tests/grid/whitespace-around.md
@@ -1,5 +1,5 @@
 ---
-title: Test page for the `grid` shortcode
+title: Whitespace handling around the `grid` shortcode
 ---
 
 <!-- prettier-ignore-start -->

--- a/src/_tests/grid/whitespace-within.md
+++ b/src/_tests/grid/whitespace-within.md
@@ -1,0 +1,273 @@
+---
+title: Test page for the `grid` shortcode
+---
+
+<!-- prettier-ignore-start -->
+<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
+<style>
+    .app-grid {
+        outline: dashed 2px grey;
+
+        > * {
+            outline: solid
+        }
+    }
+</style>
+
+## `content`
+
+### Single line
+
+{% grid %}Hello{% endgrid %}
+
+### Next line both ends
+
+{% grid %}
+Grid content
+{% endgrid %}
+
+### Line break
+
+{% grid %}
+
+Grid content
+
+{% endgrid %}
+
+### Intended
+
+{% grid %}
+    Grid content
+{% endgrid %}
+
+### Same line at start
+{% grid %}Grid content
+{% endgrid %}
+
+### Next line at start
+{% grid %}
+Grid content{% endgrid %}
+
+### Markdown
+
+#### Next line both ends
+
+{% grid %}
+A paragraph introducing:
+
+- a list
+{% endgrid %}
+
+#### Line break at start, line break at end
+
+It shouldn't have extra `<p>` from markdown transformation
+
+{% grid %}
+
+A paragraph introducing:
+
+- a list
+
+{% endgrid %}
+
+#### Indented
+
+It shouldn't be turned into a Markdown code block
+
+{% grid %}
+    A paragraph introducing:
+
+    - a list
+{% endgrid %}
+
+#### Same line at start
+
+{% grid %}A paragraph introducing:
+
+    - a list
+{% endgrid %}
+
+#### Same line at end
+
+{% grid %}
+    A paragraph introducing:
+
+    - a list{% endgrid %}
+
+### HTML
+
+#### Next line both ends
+
+{% grid %}
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+{% endgrid %}
+
+#### Line break at start, line break at end
+
+It shouldn't have extra `<p>` from Markdown transformation
+
+{% grid %}
+
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+
+{% endgrid %}
+
+#### Indented
+
+It shouldn't be turned into a Markdown code block
+
+{% grid %}
+
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+
+{% endgrid %}
+
+#### Same line at start
+
+{% grid %}<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>
+{% endgrid %}
+
+#### Same line at end
+
+{% grid %}
+<p class="govuk-body">A paragraph introducing:</p>
+
+<ul class="govuk-list">
+    <li>a list
+</ul>{% endgrid %}
+
+#### Pre-formatted text
+
+{% grid %}
+<pre>
+Hello,
+    How does this look?
+  Some space indentation as well
+</pre>
+{% endgrid %}
+
+#### Mixed with markdown
+
+##### Markdown first
+
+{% grid %}
+- a list
+- with two items
+
+<small>Followed by some HTML</small>
+{% endgrid %}
+
+##### Markdown last
+
+{% grid %}
+<small>Some HTML...</small>
+
+- a list
+- with two items
+{% endgrid %}
+
+##### Markdown around
+
+{% grid %}
+1. One
+2. Two
+
+<small>Some HTML...</small>
+
+- a list
+- with two items
+{% endgrid %}
+
+##### HTML around
+
+{% grid %}
+<small>Some initial HTML...</small>
+
+- a list
+- another list
+
+<small>HTML again</small>
+{% endgrid %}
+
+##### Markdown inside
+
+Like with any nesting of Markdown inside HTML,
+the markdown blocks need to be at the start of the line
+
+{% grid %}
+<article>
+
+###### Here's the heading
+
+And some content
+
+</article>
+{% endgrid %}
+
+Markdown blocks (headings, lists...) won't get detected if they're not at the start of the line,
+only `<p>` tags will be created
+
+{% grid %}
+<article>
+
+    ###### Here's the heading
+
+    And some content
+
+</article>
+{% endgrid %}
+
+Without a line break after the HTML opening tag, Markdown won't be detected either
+
+{% grid %}
+<article>
+Some **bold text**
+###### Here's the heading
+
+And some content, including **bold text**
+</article>
+{% endgrid %}
+
+## Surrounding content
+
+It should correctly compile the markdown before
+and after the shortcode
+
+### On different line than previous and following content
+Content before
+{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+### Same line before
+
+Content before{% grid %}
+Grid content
+{% endgrid %}
+Content after
+
+### Same line after
+
+Content before
+{% grid %}
+Grid content
+{% endgrid %}Content after
+
+<!-- prettier-ignore-end -->

--- a/src/_tests/grid/whitespace-within.md
+++ b/src/_tests/grid/whitespace-within.md
@@ -2,8 +2,8 @@
 title: Whitespace handling within the `grid` shortcode
 ---
 
-<!-- prettier-ignore-start -->
-<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
+{% css %}
+
 <style>
     .app-grid {
         outline: dashed 2px grey;
@@ -13,6 +13,11 @@ title: Whitespace handling within the `grid` shortcode
         }
     }
 </style>
+
+{% endcss %}
+
+<!-- prettier-ignore-start -->
+<!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
 
 ## `content`
 

--- a/src/_tests/grid/whitespace-within.md
+++ b/src/_tests/grid/whitespace-within.md
@@ -1,5 +1,5 @@
 ---
-title: Test page for the `grid` shortcode
+title: Whitespace handling within the `grid` shortcode
 ---
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Combines parts of other PRs to make a production-ready `grid` shortcode.

## Changes
- Added a `grid` shortcode to enable content to be laid out in a two-dimensional grid with an arbitrary number of columns. From #33.
- Added a `blockShortcode` utility function to handle whitespace within shortcodes, ensuring that the output of `grid` and other shortcodes does not get mangled by how the Markdown parser interprets whitespace characters. From #62.
- Added tests to ensure the `grid` shortcode and `blockShortcode` function output things as intended. From #62 with new tests added in this PR.
- Added `css` Eleventy bundle to allow per-page CSS styles to be hoisted into the head of a document. From #38. 
- Added config to ensure that test pages are not included in Eleventy collections, the sitemap, or are indexed by search engines. Original to this PR. 

## Thoughts
Based on Slack discussion we agreed that test pages should be viewable on production for the time being, to aid with finding and debugging issues. We may choose to make these not compile for production at a later time. 

Eleventy bundles can be configured to generate fingerprinted CSS files, which could be beneficial here as all three test pages use identical CSS. The difference it makes to developers and users is pretty negligible though, so I've opted not to do so to avoid adding a new moving part.

I've noticed doing this that Prettier really wants there to be newlines before and/or after certain Nunjucks shortcodes. Not sure if that might cause trouble later down the line. 