### PR TITLE
Have Nunjucks show whole stack traces

### DIFF
--- a/eleventy/nunjucks.js
+++ b/eleventy/nunjucks.js
@@ -9,7 +9,11 @@ export function setupNunjucks(eleventyConfig) {
     new nunjucks.FileSystemLoader([
       eleventyConfig.dir.input,
       './node_modules/govuk-frontend/dist'
-    ])
+    ]),
+    // As we take over Eleventy's Nunjucks environment, we need to replicate the same
+    // default it sets up
+    // https://github.com/11ty/eleventy/blob/2b5e72c5fbea41bd82a03472679d90ef75fc3119/src/Engines/Nunjucks.js#L19
+    eleventyConfig.nunjucksEnvironmentOptions || { dev: true }
   )
 
   // Enable the rebrand styles and assets


### PR DESCRIPTION
Use the `dev` option of Nunjucks to prevent the prettifying of stack traces. This gets in the way of understanding what actually broke shortcodes.

Eleventy does it in the default options it passes to the Nunjucks environment: https://github.com/11ty/eleventy/blob/2b5e72c5fbea41bd82a03472679d90ef75fc3119/src/Engines/Nunjucks.js#L19