### PR TITLE
Add hero image colours to frontmatter

### DIFF
--- a/src/colour/index.md
+++ b/src/colour/index.md
@@ -2,6 +2,7 @@
 order: 2
 title: Colour
 hero: ./hero.svg
+colour: '#54319F'
 ---
 
 Our colour palette is designed with accessibility in mind. It’s flexible enough to work across all GOV.UK channels.

--- a/src/graphic-device/index.md
+++ b/src/graphic-device/index.md
@@ -2,6 +2,7 @@
 order: 0
 title: Graphic device
 hero: ./hero.svg
+colour: '#158187'
 ---
 
 ## The Dot

--- a/src/index.md
+++ b/src/index.md
@@ -2,6 +2,7 @@
 order: 0
 title: GOV.UK Brand Guidelines
 hero: ./hero.svg
+colour: '#1D70B8'
 ---
 
 ## Brand ambition

--- a/src/logo-system/index.md
+++ b/src/logo-system/index.md
@@ -2,6 +2,7 @@
 order: 1
 title: Logo system
 hero: ./hero.svg
+colour: '#11875A'
 ---
 
 ## The GOV.UK logo system

--- a/src/typography/index.md
+++ b/src/typography/index.md
@@ -2,6 +2,7 @@
 order: 3
 title: Typography
 hero: ./hero.svg
+colour: '#CA357C'
 ---
 
 Typography is a core element to our identity, shaping how our brand is perceived across all GOV.UK channels.


### PR DESCRIPTION
Adding the background colour for the hero images to the frontmatter.
This is not used yet but is in preparation for displaying the hero image.
This colour could later then also be used for persisting in the navigation for the whole section, or any other place we think makes sense.