### PR TITLE
Add section highlight shortcode

### DIFF
--- a/eleventy/shortcodes.js
+++ b/eleventy/shortcodes.js
@@ -1,4 +1,5 @@
 import { grid } from './shortcodes/grid.js'
+import { sectionHighlight } from './shortcodes/section-highlight.js'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
@@ -18,4 +19,5 @@ export function setupShortcodes(eleventyConfig) {
   //
   // function grid(content, param1, param2)
   eleventyConfig.addPairedShortcode('grid', grid)
+  eleventyConfig.addPairedShortcode('sectionHighlight', sectionHighlight)
 }

--- a/eleventy/shortcodes/section-highlight.js
+++ b/eleventy/shortcodes/section-highlight.js
@@ -1,0 +1,14 @@
+import { blockShortcode } from './utils.js'
+
+// TODO: This should be updated to `blockPairedShortcode` once PR #38 has been merged!
+
+export const sectionHighlight = blockShortcode((content, options = {}) => {
+  const defaultOptions = {
+    classes: undefined
+  }
+  options = { ...defaultOptions, ...options }
+
+  return `<div class="app-section-highlight${options.classes ? ` ${options.classes}` : ''}">
+    ${content}
+  </div>`
+})

--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -1,0 +1,12 @@
+.app-section-highlight {
+  color: govuk-colour('white');
+  background-color: govuk-colour('blue');
+  @include govuk-responsive-padding(3);
+  @include govuk-responsive-margin(5, $direction: 'bottom');
+
+  [class^='govuk-heading'],
+  [class^='govuk-body'],
+  .govuk-list {
+    color: inherit;
+  }
+}

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -15,6 +15,7 @@
 @import 'govuk/components/skip-link';
 
 @import 'grid';
+@import 'section-highlight';
 
 @import 'govuk/utilities';
 @import 'govuk/overrides';

--- a/src/_tests/section-highlight/index.md
+++ b/src/_tests/section-highlight/index.md
@@ -1,0 +1,29 @@
+---
+title: Test page for the `sectionHighlight` shortcode
+---
+
+## No configuration
+
+{% sectionHighlight %}
+
+## This is a heading
+
+This is some body copy. Nisi laborum nulla fugiat deserunt cupidatat proident deserunt anim sunt nulla.
+
+- this is
+- a list
+- made of items
+  {% endsectionHighlight %}
+
+## `classes` parameter
+
+{% sectionHighlight { classes: "page-custom-class" } %}
+
+## This is a heading
+
+This is some body copy. Amet quis magna in aliquip officia.
+
+- this is
+- a list
+- made of items
+  {% endsectionHighlight %}


### PR DESCRIPTION
Adds shortcode for highlighting sections of content. This gives a section of content a blue background and changes the text within to white.

> [!WARNING]
> This uses the `blockShortcode` function. #38 has split this function in two, creating a new `blockPairedShortcode` function, which this code should be updated to use once available. 

## Changes
- Added `sectionHighlight` shortcode.
- Added test page for the shortcode.

## Usage

```nunj
{% sectionHighlight %}
## This is a heading.

This is some body copy. Beep boop beep.

- This is a list
- With a few list items
- Let's go!
{% endsectionHighlight %}
```

Be wary of the capitalisation of the end tag, as it's case-sensitive. 