### PR TITLE
Add utility classes and shortcodes to help with testing pages

### DIFF
--- a/eleventy/shortcodes.js
+++ b/eleventy/shortcodes.js
@@ -1,5 +1,6 @@
 import { grid } from './shortcodes/grid.js'
 import { sectionHighlight } from './shortcodes/section-highlight.js'
+import { testExample } from './shortcodes/test-example.js'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
@@ -20,4 +21,5 @@ export function setupShortcodes(eleventyConfig) {
   // function grid(content, param1, param2)
   eleventyConfig.addPairedShortcode('grid', grid)
   eleventyConfig.addPairedShortcode('sectionHighlight', sectionHighlight)
+  eleventyConfig.addPairedShortcode('testExample', testExample)
 }

--- a/eleventy/shortcodes/test-example.js
+++ b/eleventy/shortcodes/test-example.js
@@ -1,0 +1,5 @@
+import { blockShortcode } from './utils.js'
+
+export const testExample = blockShortcode((content) => {
+  return `<div class="test-example">${content}</div>`
+})

--- a/src/_layouts/test.njk
+++ b/src/_layouts/test.njk
@@ -1,0 +1,6 @@
+{% extends "./generic.njk" %}
+
+{% block head %}
+ {{ super() }}
+ <link rel="stylesheet" href="{{ '/assets/tests.css' | url }}">
+{% endblock %}

--- a/src/_stylesheets/tests.scss
+++ b/src/_stylesheets/tests.scss
@@ -74,3 +74,14 @@
   background-position: 0 var(--y);
   background-size: 100% 1px;
 }
+
+.test-example {
+  margin-bottom: govuk-spacing(3);
+  padding: govuk-spacing(3);
+  overflow: hidden;
+  border: solid 2px govuk-colour('blue');
+  background-image:
+    linear-gradient(#ffffff),
+    linear-gradient(govuk-tint(govuk-colour('light-blue'), 80%));
+  background-clip: content-box, border-box;
+}

--- a/src/_stylesheets/tests.scss
+++ b/src/_stylesheets/tests.scss
@@ -30,3 +30,47 @@
 
   outline-offset: -2px;
 }
+
+//////
+/// Guide lines
+///
+/// Use these classes to draw lines over an element to verify alignment
+//////
+.test-guide-line--vertical,
+.test-guide-line--horizontal {
+  position: relative;
+  z-index: 0;
+
+  // Use custom properties to allow easily changing the position from the element itself
+  --x: 50%;
+  --y: 50%;
+  --guide-line-colour: #{govuk-colour('pink')};
+  --vertical-guide-line-colour: var(--guide-line-colour);
+  --horizontal-guide-line-colour: var(--guide-line-colour);
+}
+
+.test-guide-line--vertical::before,
+.test-guide-line--horizontal::after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-repeat: no-repeat;
+  pointer-events: none;
+}
+
+.test-guide-line--vertical::before {
+  background-image: linear-gradient(var(--vertical-guide-line-colour));
+  background-position: var(--x) 0;
+  background-size: 1px 100%;
+}
+
+.test-guide-line--horizontal::after {
+  background-image: linear-gradient(var(--horizontal-guide-line-colour));
+  background-position: 0 var(--y);
+  background-size: 100% 1px;
+}

--- a/src/_stylesheets/tests.scss
+++ b/src/_stylesheets/tests.scss
@@ -12,17 +12,20 @@
 /// <div class=".test-outline--loose">I have an outline a little outside</div>
 /// <div class=".test-outline--tight">I have an outline a little inside</div>
 //////
-.test-outline {
+.test-outline,
+.test-outline-children > * {
   outline: solid 2px;
 }
 
-.test-outline--loose {
+.test-outline--loose,
+.test-outline-children--loose > * {
   outline: dotted 2px govuk-colour('bright-purple');
 
   outline-offset: 2px;
 }
 
-.test-outline--tight {
+.test-outline--tight,
+.test-outline-children--tight > * {
   outline: dashed 2px govuk-colour('turquoise');
 
   outline-offset: -2px;

--- a/src/_stylesheets/tests.scss
+++ b/src/_stylesheets/tests.scss
@@ -1,0 +1,29 @@
+/// Classes to help build component's test pages
+@use 'govuk/base' as * with (
+  $govuk-new-typography-scale: true
+);
+
+//////
+/// Outlines
+///
+/// Use these classes to outline specific elements in the tests
+///
+/// @example
+/// <div class=".test-outline--loose">I have an outline a little outside</div>
+/// <div class=".test-outline--tight">I have an outline a little inside</div>
+//////
+.test-outline {
+  outline: solid 2px;
+}
+
+.test-outline--loose {
+  outline: dotted 2px govuk-colour('bright-purple');
+
+  outline-offset: 2px;
+}
+
+.test-outline--tight {
+  outline: dashed 2px govuk-colour('turquoise');
+
+  outline-offset: -2px;
+}

--- a/src/_tests/_tests.11tydata.js
+++ b/src/_tests/_tests.11tydata.js
@@ -1,12 +1,11 @@
-export default function () {
-  return {
-    // Don't include pages in this directory in Eleventy collections
-    // Prevents it being included in sitemap, global navigation, etc.
-    eleventyExcludeFromCollections: true,
+export default {
+  layout: 'test.njk',
+  // Don't include pages in this directory in Eleventy collections
+  // Prevents it being included in sitemap, global navigation, etc.
+  eleventyExcludeFromCollections: true,
 
-    // Set robots meta tag to `noindex, nofollow` on these pages in production
-    metadata: {
-      noRobots: true
-    }
+  // Set robots meta tag to `noindex, nofollow` on these pages in production
+  metadata: {
+    noRobots: true
   }
 }

--- a/src/_tests/grid/index.md
+++ b/src/_tests/grid/index.md
@@ -6,13 +6,14 @@ title: Test page for the `grid` shortcode
 
 1 column across all breakpoints.
 
-{% grid {classes: 'test-outline-children test-outline--loose'} %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid {classes: 'test-outline-children test-outline--loose'} %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 ## `columns` parameter
 
@@ -20,13 +21,14 @@ title: Test page for the `grid` shortcode
 
 2 columns on mobile, which is inherited by tablet and desktop.
 
-{% grid { columns: { mobile: 2 }, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: { mobile: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 #### Alternate syntax
 
@@ -34,58 +36,63 @@ Number of columns passed as a number instead of an object.
 
 2 columns on mobile, which is inherited by tablet and desktop.
 
-{% grid { columns: 2, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: 2, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 ### Tablet configuration only
 
 1 column on mobile. 2 columns on tablet, which is inherited by desktop.
 
-{% grid { columns: { tablet: 2 }, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: { tablet: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 ### Desktop configuration only
 
 1 column on mobile and tablet. 2 columns on desktop.
 
-{% grid { columns: { desktop: 2 }, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: { desktop: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 ### Hybrid configuration
 
 2 columns on mobile and 4 columns on desktop. Tablet inherits from mobile.
 
-{% grid { columns: { mobile: 2, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: { mobile: 2, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}
 
 ### All sizes configured
 
 2 columns on mobile, 3 on tablet, 4 on desktop.
 
-{% grid { columns: { mobile: 2, tablet: 3, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
-
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% testExample %}
+    {% grid { columns: { mobile: 2, tablet: 3, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+    {% endgrid %}
+{% endtestExample %}

--- a/src/_tests/grid/index.md
+++ b/src/_tests/grid/index.md
@@ -2,25 +2,12 @@
 title: Test page for the `grid` shortcode
 ---
 
-{% css %}
-
-<style>
-    .app-grid {
-        outline: dashed 2px grey;
-    
-        > * {
-            outline: solid
-        }
-    }
-</style>
-
-{% endcss %}
-
 ## No configuration
 
 1 column across all breakpoints.
 
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -33,7 +20,8 @@ title: Test page for the `grid` shortcode
 
 2 columns on mobile, which is inherited by tablet and desktop.
 
-{% grid { columns: { mobile: 2 } } %}
+{% grid { columns: { mobile: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -46,7 +34,8 @@ Number of columns passed as a number instead of an object.
 
 2 columns on mobile, which is inherited by tablet and desktop.
 
-{% grid { columns: 2 } %}
+{% grid { columns: 2, classes: 'test-outline-children test-outline--loose' } %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -57,7 +46,8 @@ Number of columns passed as a number instead of an object.
 
 1 column on mobile. 2 columns on tablet, which is inherited by desktop.
 
-{% grid { columns: { tablet: 2 } } %}
+{% grid { columns: { tablet: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -68,7 +58,8 @@ Number of columns passed as a number instead of an object.
 
 1 column on mobile and tablet. 2 columns on desktop.
 
-{% grid { columns: { desktop: 2 } } %}
+{% grid { columns: { desktop: 2 }, classes: 'test-outline-children test-outline--loose' } %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -79,7 +70,8 @@ Number of columns passed as a number instead of an object.
 
 2 columns on mobile and 4 columns on desktop. Tablet inherits from mobile.
 
-{% grid { columns: { mobile: 2, desktop: 4 } } %}
+{% grid { columns: { mobile: 2, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
+
 <div>1</div>
 <div>2</div>
 <div>3</div>
@@ -90,16 +82,8 @@ Number of columns passed as a number instead of an object.
 
 2 columns on mobile, 3 on tablet, 4 on desktop.
 
-{% grid { columns: { mobile: 2, tablet: 3, desktop: 4 } } %}
-<div>1</div>
-<div>2</div>
-<div>3</div>
-<div>4</div>
-{% endgrid %}
+{% grid { columns: { mobile: 2, tablet: 3, desktop: 4 }, classes: 'test-outline-children test-outline--loose' } %}
 
-## `classes` parameter
-
-{% grid { columns: 2, classes: "page-custom-grid" } %}
 <div>1</div>
 <div>2</div>
 <div>3</div>

--- a/src/_tests/grid/whitespace-around.md
+++ b/src/_tests/grid/whitespace-around.md
@@ -28,7 +28,7 @@ It should correctly compile the markdown before and after the shortcode
 #### On different line than previous and following content
 
 Content before
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
 Content after
@@ -36,7 +36,7 @@ Content after
 ### Within markdown block
 
 - First item
-    {% grid {indent: 2} %}
+    {% grid {indent: 2, classes: 'test-outline-children test-outline--loose'} %}
     Grid content
     {% endgrid %}
 - Second item
@@ -45,7 +45,7 @@ Content after
 
 Content before
 
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
 
@@ -54,7 +54,7 @@ Content after
 
 #### Same line before
 
-Content before{% grid %}
+Content before{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 Content after
@@ -72,7 +72,7 @@ Grid content
 #### Tags before and after
 
 <p class="govuk-body">Content before</p>
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 <p class="govuk-body">Content after</p>
@@ -83,7 +83,7 @@ Shouldn't add extra paragraphs when Markdown is processed
 
 <p class="govuk-body">Content before</p>
 
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 
@@ -92,7 +92,7 @@ Grid content
 #### At start of tag
 
 <article>
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 </article>
@@ -101,7 +101,7 @@ Grid content
 
 <article>
 Content before
-{% grid {insideHTML: true} %}
+{% grid {insideHTML: true, classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
 Content after
@@ -111,7 +111,7 @@ Content after
 
 <article>
 <span>Content before</span>
-{% grid {insideHTML: true} %}
+{% grid {insideHTML: true, classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
 <span>Content after</span>
@@ -121,7 +121,7 @@ Grid content
 
 <article>
 <ul><li>Content before</ul>
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 <ul><li>Content after</ul>
@@ -130,7 +130,7 @@ Grid content
 ### Markdown before, HTML after
 
 - A list before
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 <ul><li>Content after</ul>
@@ -138,7 +138,7 @@ Grid content
 ### HTML before, Markdown after
 
 <ul><li>Content before</ul>
-{% grid %}
+{% grid {classes: 'test-outline-children test-outline--loose'}%}
 Grid content
 {% endgrid %}
 - A list after

--- a/src/_tests/grid/whitespace-within.md
+++ b/src/_tests/grid/whitespace-within.md
@@ -2,20 +2,6 @@
 title: Whitespace handling within the `grid` shortcode
 ---
 
-{% css %}
-
-<style>
-    .app-grid {
-        outline: dashed 2px grey;
-
-        > * {
-            outline: solid
-        }
-    }
-</style>
-
-{% endcss %}
-
 <!-- prettier-ignore-start -->
 <!-- This file has a few tests about managing whitespace so we need it to stay as authored -->
 
@@ -23,99 +9,124 @@ title: Whitespace handling within the `grid` shortcode
 
 ### Single line
 
-{% grid %}Hello{% endgrid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}Hello{% endgrid %}
+{% endtestExample %}
 
 ### Next line both ends
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
+{% endtestExample %}
 
 ### Line break
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 
 Grid content
 
 {% endgrid %}
+{% endtestExample %}
 
 ### Intended
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
     Grid content
 {% endgrid %}
+{% endtestExample %}
 
 ### Same line at start
-{% grid %}Grid content
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}Grid content
 {% endgrid %}
+{% endtestExample %}
 
 ### Next line at start
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content{% endgrid %}
+{% endtestExample %}
 
 ### Markdown
 
 #### Next line both ends
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 A paragraph introducing:
 
 - a list
 {% endgrid %}
+{% endtestExample %}
 
 #### Line break at start, line break at end
 
 It shouldn't have extra `<p>` from markdown transformation
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 
 A paragraph introducing:
 
 - a list
 
 {% endgrid %}
+{% endtestExample %}
 
 #### Indented
 
 It shouldn't be turned into a Markdown code block
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
     A paragraph introducing:
 
     - a list
 {% endgrid %}
+{% endtestExample %}
 
 #### Same line at start
 
-{% grid %}A paragraph introducing:
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}A paragraph introducing:
 
     - a list
 {% endgrid %}
+{% endtestExample %}
 
 #### Same line at end
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
     A paragraph introducing:
 
     - a list{% endgrid %}
+    {% endtestExample %}
 
 ### HTML
 
 #### Next line both ends
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <p class="govuk-body">A paragraph introducing:</p>
 
 <ul class="govuk-list">
     <li>a list
 </ul>
 {% endgrid %}
+{% endtestExample %}
 
 #### Line break at start, line break at end
 
 It shouldn't have extra `<p>` from Markdown transformation
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 
 <p class="govuk-body">A paragraph introducing:</p>
 
@@ -124,12 +135,14 @@ It shouldn't have extra `<p>` from Markdown transformation
 </ul>
 
 {% endgrid %}
+{% endtestExample %}
 
 #### Indented
 
 It shouldn't be turned into a Markdown code block
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 
 <p class="govuk-body">A paragraph introducing:</p>
 
@@ -138,58 +151,70 @@ It shouldn't be turned into a Markdown code block
 </ul>
 
 {% endgrid %}
+{% endtestExample %}
 
 #### Same line at start
 
-{% grid %}<p class="govuk-body">A paragraph introducing:</p>
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}<p class="govuk-body">A paragraph introducing:</p>
 
 <ul class="govuk-list">
     <li>a list
 </ul>
 {% endgrid %}
+{% endtestExample %}
 
 #### Same line at end
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <p class="govuk-body">A paragraph introducing:</p>
 
 <ul class="govuk-list">
     <li>a list
 </ul>{% endgrid %}
+{% endtestExample %}
 
 #### Pre-formatted text
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <pre>
 Hello,
     How does this look?
   Some space indentation as well
 </pre>
 {% endgrid %}
+{% endtestExample %}
 
 #### Mixed with markdown
 
 ##### Markdown first
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 - a list
 - with two items
 
 <small>Followed by some HTML</small>
 {% endgrid %}
+{% endtestExample %}
 
 ##### Markdown last
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <small>Some HTML...</small>
 
 - a list
 - with two items
 {% endgrid %}
+{% endtestExample %}
 
 ##### Markdown around
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 1. One
 2. Two
 
@@ -198,10 +223,12 @@ Hello,
 - a list
 - with two items
 {% endgrid %}
+{% endtestExample %}
 
 ##### HTML around
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <small>Some initial HTML...</small>
 
 - a list
@@ -209,13 +236,15 @@ Hello,
 
 <small>HTML again</small>
 {% endgrid %}
+{% endtestExample %}
 
 ##### Markdown inside
 
 Like with any nesting of Markdown inside HTML,
 the markdown blocks need to be at the start of the line
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <article>
 
 ###### Here's the heading
@@ -224,11 +253,13 @@ And some content
 
 </article>
 {% endgrid %}
+{% endtestExample %}
 
 Markdown blocks (headings, lists...) won't get detected if they're not at the start of the line,
 only `<p>` tags will be created
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <article>
 
     ###### Here's the heading
@@ -237,10 +268,12 @@ only `<p>` tags will be created
 
 </article>
 {% endgrid %}
+{% endtestExample %}
 
 Without a line break after the HTML opening tag, Markdown won't be detected either
 
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 <article>
 Some **bold text**
 ###### Here's the heading
@@ -248,6 +281,7 @@ Some **bold text**
 And some content, including **bold text**
 </article>
 {% endgrid %}
+{% endtestExample %}
 
 ## Surrounding content
 
@@ -256,23 +290,29 @@ and after the shortcode
 
 ### On different line than previous and following content
 Content before
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
+{% endtestExample %}
 Content after
 
 ### Same line before
 
-Content before{% grid %}
+{% testExample %}Content before
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
 {% endgrid %}
+{% endtestExample %}
 Content after
 
 ### Same line after
 
 Content before
-{% grid %}
+{% testExample %}
+{% grid {classes: 'test-outline-children test-outline--loose'} %}
 Grid content
-{% endgrid %}Content after
+{% endgrid %}
+{% endtestExample %}Content after
 
 <!-- prettier-ignore-end -->

--- a/src/_tests/utilities/index.md
+++ b/src/_tests/utilities/index.md
@@ -50,3 +50,55 @@ And some more
 And some more
 
 </div>
+
+## Overlaying guides
+
+To check alignment, you can overlay guides drawing a line at a specific horizontal or vertical position using:
+
+- `test-guide-line--vertical` for a vertical line
+- `test-guide-line--horizontal` for a horizontal line
+
+The position of the line is controlled by setting a `--x` or `--y` custom property (depending on the orientation) in the `style` attribute. It accepts any valid value for [`background-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position).
+
+### Vertical guideline
+
+<div class="test-guide-line--vertical" style="--x: 20px">
+
+- Let's see a list
+- With some items
+- and some more
+
+</div>
+
+### Horizontal guideline
+
+<div class="test-guide-line--horizontal" style="--y: 11px">
+
+Some content
+
+</div>
+
+### Combined
+
+<div class="test-guide-line--vertical test-guide-line--horizontal" style="--x: 20px; --y: 11px">
+
+- Let's see a list
+- With some items
+- and some more
+
+</div>
+
+When using both guide lines, you may want to customise the colour of each of them, which can be done with the `--vertical-guide-line-colour` and `--horizontal-guide-line-colour` properties
+
+<div class="test-guide-line--vertical test-guide-line--horizontal" 
+    style="
+        --x: 20px; 
+        --y: 11px; 
+        --vertical-guide-line-colour: rebeccapurple;
+        --horizontal-guide-line-colour: blue">
+
+- Let's see a list
+- With some items
+- and some more
+
+</div>

--- a/src/_tests/utilities/index.md
+++ b/src/_tests/utilities/index.md
@@ -6,6 +6,8 @@ To facilitate creating test pages, we have a couple of utilities
 
 ## Outlines CSS classes
 
+### Outlining elements
+
 Use the following classes on your elements to give them an outline
 and make them visually recognisable in the tests:
 
@@ -16,3 +18,35 @@ and make them visually recognisable in the tests:
 <p class="govuk-body test-outline">.test-outline</p>
 <p class="govuk-body test-outline--loose">.test-outline--loose</p>
 <p class="govuk-body test-outline--tight">.test-outline--tight</p>
+
+### Outlining children
+
+If you need to outline children of an element in bulk, you can use the following classes:
+
+- `test-outline-children`
+- `test-outline-children--loose`
+- `test-outline-children--tight`
+
+<div class="test-outline-children">
+
+`.test-outline-children`
+
+And some more
+
+</div>
+
+<div class="test-outline-children--loose">
+
+`.test-outline-children--loose`
+
+And some more
+
+</div>
+
+<div class="test-outline-children--tight">
+
+`.test-outline-children--tight`
+
+And some more
+
+</div>

--- a/src/_tests/utilities/index.md
+++ b/src/_tests/utilities/index.md
@@ -4,6 +4,16 @@ title: Test utilities
 
 To facilitate creating test pages, we have a couple of utilities
 
+## Test example shortcode
+
+The `{{"{% testExample %}"}}` paired shortcode creates an area in which to render the test.
+It prevents its children from overflowing but the padding around the test allows to detect
+if something is not where it should be.
+
+{% testExample %}
+Test render goes here
+{% endtestExample %}
+
 ## Outlines CSS classes
 
 ### Outlining elements
@@ -15,9 +25,13 @@ and make them visually recognisable in the tests:
 - `test-outline--loose`: A dotted outline 2px outside the boundary of the element
 - `test-outline--tight`: A dashed outline sitting inside the element (same as a border)
 
+{% testExample %}
+
 <p class="govuk-body test-outline">.test-outline</p>
 <p class="govuk-body test-outline--loose">.test-outline--loose</p>
 <p class="govuk-body test-outline--tight">.test-outline--tight</p>
+
+{% endtestExample %}
 
 ### Outlining children
 
@@ -27,6 +41,8 @@ If you need to outline children of an element in bulk, you can use the following
 - `test-outline-children--loose`
 - `test-outline-children--tight`
 
+{% testExample %}
+
 <div class="test-outline-children">
 
 `.test-outline-children`
@@ -35,19 +51,29 @@ And some more
 
 </div>
 
+{% endtestExample %}
+
+{% testExample %}
+
 <div class="test-outline-children--loose">
 
 `.test-outline-children--loose`
 
 And some more
 
+{% endtestExample %}
+
 </div>
+
+{% testExample %}
 
 <div class="test-outline-children--tight">
 
 `.test-outline-children--tight`
 
 And some more
+
+{% endtestExample %}
 
 </div>
 
@@ -62,6 +88,8 @@ The position of the line is controlled by setting a `--x` or `--y` custom proper
 
 ### Vertical guideline
 
+{% testExample %}
+
 <div class="test-guide-line--vertical" style="--x: 20px">
 
 - Let's see a list
@@ -70,7 +98,11 @@ The position of the line is controlled by setting a `--x` or `--y` custom proper
 
 </div>
 
+{% endtestExample %}
+
 ### Horizontal guideline
+
+{% testExample %}
 
 <div class="test-guide-line--horizontal" style="--y: 11px">
 
@@ -78,7 +110,11 @@ Some content
 
 </div>
 
+{% endtestExample %}
+
 ### Combined
+
+{% testExample %}
 
 <div class="test-guide-line--vertical test-guide-line--horizontal" style="--x: 20px; --y: 11px">
 
@@ -88,7 +124,11 @@ Some content
 
 </div>
 
+{% endtestExample %}
+
 When using both guide lines, you may want to customise the colour of each of them, which can be done with the `--vertical-guide-line-colour` and `--horizontal-guide-line-colour` properties
+
+{% testExample %}
 
 <div class="test-guide-line--vertical test-guide-line--horizontal" 
     style="
@@ -102,3 +142,5 @@ When using both guide lines, you may want to customise the colour of each of the
 - and some more
 
 </div>
+
+{% endtestExample %}

--- a/src/_tests/utilities/index.md
+++ b/src/_tests/utilities/index.md
@@ -1,0 +1,18 @@
+---
+title: Test utilities
+---
+
+To facilitate creating test pages, we have a couple of utilities
+
+## Outlines CSS classes
+
+Use the following classes on your elements to give them an outline
+and make them visually recognisable in the tests:
+
+- `test-outline`: A regular solid outline sitting on the outside of the element
+- `test-outline--loose`: A dotted outline 2px outside the boundary of the element
+- `test-outline--tight`: A dashed outline sitting inside the element (same as a border)
+
+<p class="govuk-body test-outline">.test-outline</p>
+<p class="govuk-body test-outline--loose">.test-outline--loose</p>
+<p class="govuk-body test-outline--tight">.test-outline--tight</p>


### PR DESCRIPTION
Adds a separate stylesheet for test pages with utility classes to help check things in the test pages, as well as a shortcode to delimitate the area in which test HTML is rendered:

- a `testExample` shortcode to delimitate the area of the page where the test is rendered
	
	<img width="680" height="118" alt="Screenshot of the area delimitating a test example" src="https://github.com/user-attachments/assets/30020c8b-5af4-4815-8226-c654ba1cb03b" />
- `.test-outline` to outline elements (with `--loose` and `--tight` variant)
	
	<img width="654" height="188" alt="Screenshot of element outline examples" src="https://github.com/user-attachments/assets/1873d45d-113d-4dc8-8543-00cf43f6efdb" />
- `.test-outline-children` to outline children of an element (with the same `--loose` and `--tight` variants)
	
	<img width="677" height="141" alt="Screenshot children outline example" src="https://github.com/user-attachments/assets/4440abd1-3ee1-4152-94bc-09f6c4ed23bb" />
- `.test-guide-line--horizontal` and `.test-guide-line--vertical` to overlay guide lines over an element
	
	<img width="676" height="502" alt="Screenshot guide lines" src="https://github.com/user-attachments/assets/6b992ec5-4ba4-4414-89b8-12c53f1c0a19" />
	
These are all displayed in [this test page on the preview app](https://deploy-preview-82--govuk-brand-guidelines.netlify.app/_tests/utilities/).
