### PR TITLE
Import missing scss file for the inform/inspire section

### DIFF
--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -16,6 +16,7 @@
 
 @import 'aria-current';
 @import 'grid';
+@import 'inform-inspire';
 @import 'inline-copy';
 @import 'link-list';
 @import 'mobile-navigation-section';


### PR DESCRIPTION
Seems the `@import` statement got lost in the rebase before merging the design branches.