### PR TITLE
[FOR DISCUSSION] Refactor shortcode params & document with JSDoc

### DIFF
--- a/eleventy/shortcodes/grid.js
+++ b/eleventy/shortcodes/grid.js
@@ -1,37 +1,37 @@
 import { blockPairedShortcode } from './utils.js'
 
-export const grid = blockPairedShortcode(
-  /**
-   * Wraps the content in a grid of the specified number of columns
-   *
-   * @param {string} content - The content of the grid
-   * @param {options} options
-   * @param {string} [options.classes] - A space separated list of CSS classes to add to the grid's `class` attribute
-   * @param {number | ResponsiveValue<number>} options.columns - The number of columns in the grid
-   * @returns
-   */
-  function (content, { classes, columns } = {}) {
-    // Assemble custom properties
-    const cssProperties = []
-    if (typeof columns === 'number') {
-      cssProperties.push(`--app-grid-columns-mobile: ${columns}`)
-    } else if (typeof columns === 'object') {
-      if (columns.mobile) {
-        cssProperties.push(`--app-grid-columns-mobile: ${columns.mobile}`)
-      }
-      if (columns.tablet) {
-        cssProperties.push(`--app-grid-columns-tablet: ${columns.tablet}`)
-      }
-      if (columns.desktop) {
-        cssProperties.push(`--app-grid-columns-desktop: ${columns.desktop}`)
-      }
-    }
+export const grid = blockPairedShortcode(_grid)
 
-    return `<div class="app-grid${classes ? ` ${classes}` : ''}" style="${cssProperties.join(';')}">
-    ${content}
-  </div>`
+/**
+ * Wraps the content in a grid of the specified number of columns
+ *
+ * @param {string} content - The content of the grid
+ * @param {options} options
+ * @param {string} [options.classes] - A space separated list of CSS classes to add to the grid's `class` attribute
+ * @param {number | ResponsiveValue<number>} options.columns - The number of columns in the grid
+ * @returns
+ */
+function _grid(content, { classes, columns } = {}) {
+  // Assemble custom properties
+  const cssProperties = []
+  if (typeof columns === 'number') {
+    cssProperties.push(`--app-grid-columns-mobile: ${columns}`)
+  } else if (typeof columns === 'object') {
+    if (columns.mobile) {
+      cssProperties.push(`--app-grid-columns-mobile: ${columns.mobile}`)
+    }
+    if (columns.tablet) {
+      cssProperties.push(`--app-grid-columns-tablet: ${columns.tablet}`)
+    }
+    if (columns.desktop) {
+      cssProperties.push(`--app-grid-columns-desktop: ${columns.desktop}`)
+    }
   }
-)
+
+  return `<div class="app-grid${classes ? ` ${classes}` : ''}" style="${cssProperties.join(';')}">
+  ${content}
+</div>`
+}
 
 /**
  * An object representing responsive values of a given type

--- a/eleventy/shortcodes/section-highlight.js
+++ b/eleventy/shortcodes/section-highlight.js
@@ -1,17 +1,17 @@
 import { blockPairedShortcode } from './utils.js'
 
-export const sectionHighlight = blockPairedShortcode(
-  /**
-   * Wraps the content in a section whose design makes it stand out from the page
-   *
-   * @param {string} content - The content of the section
-   * @param {object} options
-   * @param {string} [options.classes] - A space separated list of CSS classes to add to the section's `class` attribute
-   * @returns
-   */
-  function (content, { classes } = {}) {
-    return `<div class="app-section-highlight${classes ? ` ${classes}` : ''}">
-    ${content}
-  </div>`
-  }
-)
+export const sectionHighlight = blockPairedShortcode(_sectionHighlight)
+
+/**
+ * Wraps the content in a section whose design makes it stand out from the page
+ *
+ * @param {string} content - The content of the section
+ * @param {object} options
+ * @param {string} [options.classes] - A space separated list of CSS classes to add to the section's `class` attribute
+ * @returns
+ */
+function _sectionHighlight(content, { classes } = {}) {
+  return `<div class="app-section-highlight${classes ? ` ${classes}` : ''}">
+  ${content}
+</div>`
+}

--- a/eleventy/shortcodes/swatch-list.js
+++ b/eleventy/shortcodes/swatch-list.js
@@ -1,33 +1,33 @@
 import { blockShortcode } from './utils.js'
 import { swatch } from './swatch.js'
 
-export const swatchList = blockShortcode(
-  /**
-   * Renders a list of swatches from the provided palette, optionally filtered by group or use
-   *
-   * @param {object} options
-   * @param {string} [options.classes] - A space separated list of CSS classes to add to the swatch list's `class` attribute
-   * @param {string} [options.palette] - The palette from which to pull the colours, default to the one in the site's data
-   * @param {string} [options.group] - Filter for the group of colour (eg. 'blue', 'green', 'red',...) to render from the palette
-   * @param {string} [options.use] - Filter for the use of the colour ('web', 'app',...) to render from the palette
-   * @returns {string}
-   */
-  function ({ classes, palette, use, group } = {}) {
-    palette ??= this.ctx.colours ?? []
+export const swatchList = blockShortcode(_swatchList)
 
-    // Get an array of colours for the given options
-    let colourList = filterColours(palette, use, group)
+/**
+ * Renders a list of swatches from the provided palette, optionally filtered by group or use
+ *
+ * @param {object} options
+ * @param {string} [options.classes] - A space separated list of CSS classes to add to the swatch list's `class` attribute
+ * @param {string} [options.palette] - The palette from which to pull the colours, default to the one in the site's data
+ * @param {string} [options.group] - Filter for the group of colour (eg. 'blue', 'green', 'red',...) to render from the palette
+ * @param {string} [options.use] - Filter for the use of the colour ('web', 'app',...) to render from the palette
+ * @returns {string}
+ */
+function _swatchList({ classes, palette, use, group } = {}) {
+  palette ??= this.ctx.colours ?? []
 
-    // Modify the array to implant the print option and indicate this is a list of swatches
-    colourList = colourList.map((c) => {
-      return { ...c, print: use === 'print', isInSwatchList: true }
-    })
+  // Get an array of colours for the given options
+  let colourList = filterColours(palette, use, group)
 
-    return `<dl class="app-swatch-list${classes ? ` ${classes}` : ''}">
-    ${colourList.map((c) => swatch(c)).join(' ')}
-  </dl>`
-  }
-)
+  // Modify the array to implant the print option and indicate this is a list of swatches
+  colourList = colourList.map((c) => {
+    return { ...c, print: use === 'print', isInSwatchList: true }
+  })
+
+  return `<dl class="app-swatch-list${classes ? ` ${classes}` : ''}">
+  ${colourList.map((c) => swatch(c)).join(' ')}
+</dl>`
+}
 
 export function filterColours(palette, use, group) {
   if (use) {

--- a/eleventy/shortcodes/swatch.js
+++ b/eleventy/shortcodes/swatch.js
@@ -1,73 +1,73 @@
 import { blockShortcode } from './utils.js'
 
-export const swatch = blockShortcode(
-  /**
-   * Renders a colour swatch, including name, visual sample and colour codes
-   *
-   * @param {object} options
-   * @param {string} [options.classes] - A space separated list of CSS classes to add to the swatch's `class` attribute
-   * @param {string} [options.hex] - The hexadecimal representation of the colour
-   * @param {number[]} [options.cmyk] - The CMYK representation of the colour
-   * @param {string} [options.pantone] - The name of the pantone colour
-   * @param {string} options.label - The name of the colour in the brand colour system
-   * @param {boolean} [options.print] - Whether the swatch should render the colours for print
-   * @param {isInSwatchList} [options.isInSwatchList] - Removes the wrapping `dl` element if this is an item in a list of swatches
-   * @returns {string}
-   */
-  function ({
-    classes,
-    hex = '#000',
-    cmyk = [],
-    pantone,
-    label = 'Unnamed',
-    print = false,
-    isInSwatchList = false
-  } = {}) {
-    // Hex values are 1:1 translatable into RGB values, so we convert them
-    // instead of storing both separately.
-    const colourRGB = convertHexToRGB(hex)
+export const swatch = blockShortcode(_swatch)
 
-    // Assemble values to display
-    let colourValues = []
-    if (print) {
-      // Not all print colours in the palette have defined CMYK and Pantone
-      // equivalents (e.g. white), so those need conditional checks
-      if (cmyk.length) {
-        colourValues.push({
-          label: `CMYK ${cmyk.join(' ')}`,
-          value: cmyk.join(' ')
-        })
-      }
-      if (pantone) {
-        colourValues.push({ label: pantone, value: pantone })
-      }
-    } else {
-      colourValues = [
-        { label: `RGB ${colourRGB.join(' ')}`, value: colourRGB.join(' ') },
-        { label: hex.toUpperCase(), value: hex }
-      ]
+/**
+ * Renders a colour swatch, including name, visual sample and colour codes
+ *
+ * @param {object} options
+ * @param {string} [options.classes] - A space separated list of CSS classes to add to the swatch's `class` attribute
+ * @param {string} [options.hex] - The hexadecimal representation of the colour
+ * @param {number[]} [options.cmyk] - The CMYK representation of the colour
+ * @param {string} [options.pantone] - The name of the pantone colour
+ * @param {string} options.label - The name of the colour in the brand colour system
+ * @param {boolean} [options.print] - Whether the swatch should render the colours for print
+ * @param {isInSwatchList} [options.isInSwatchList] - Removes the wrapping `dl` element if this is an item in a list of swatches
+ * @returns {string}
+ */
+function _swatch({
+  classes,
+  hex = '#000',
+  cmyk = [],
+  pantone,
+  label = 'Unnamed',
+  print = false,
+  isInSwatchList = false
+} = {}) {
+  // Hex values are 1:1 translatable into RGB values, so we convert them
+  // instead of storing both separately.
+  const colourRGB = convertHexToRGB(hex)
+
+  // Assemble values to display
+  let colourValues = []
+  if (print) {
+    // Not all print colours in the palette have defined CMYK and Pantone
+    // equivalents (e.g. white), so those need conditional checks
+    if (cmyk.length) {
+      colourValues.push({
+        label: `CMYK ${cmyk.join(' ')}`,
+        value: cmyk.join(' ')
+      })
     }
-
-    // Assemble the label's HTML
-    const $values = colourValues.map(
-      ({ label, value }) =>
-        `<dd class="app-swatch__value" data-module="app-inline-copy" data-copy-value="${value}">${label}</dd>`
-    )
-
-    const $label = label
-      ? `<dt class="app-swatch__name">${label}</dt>
-      ${$values.join(' ')}`
-      : ''
-
-    // Assemble attributes for the wrapping element separately, as what element
-    // that is changes depending on `isInSwatchList`
-    const attributes = `class="app-swatch${classes ? ` ${classes}` : ''}" style="--app-swatch-colour:${hex};"`
-
-    return isInSwatchList
-      ? `<div ${attributes}>${$label}</div>`
-      : `<dl ${attributes}>${$label}</dl>`
+    if (pantone) {
+      colourValues.push({ label: pantone, value: pantone })
+    }
+  } else {
+    colourValues = [
+      { label: `RGB ${colourRGB.join(' ')}`, value: colourRGB.join(' ') },
+      { label: hex.toUpperCase(), value: hex }
+    ]
   }
-)
+
+  // Assemble the label's HTML
+  const $values = colourValues.map(
+    ({ label, value }) =>
+      `<dd class="app-swatch__value" data-module="app-inline-copy" data-copy-value="${value}">${label}</dd>`
+  )
+
+  const $label = label
+    ? `<dt class="app-swatch__name">${label}</dt>
+    ${$values.join(' ')}`
+    : ''
+
+  // Assemble attributes for the wrapping element separately, as what element
+  // that is changes depending on `isInSwatchList`
+  const attributes = `class="app-swatch${classes ? ` ${classes}` : ''}" style="--app-swatch-colour:${hex};"`
+
+  return isInSwatchList
+    ? `<div ${attributes}>${$label}</div>`
+    : `<dl ${attributes}>${$label}</dl>`
+}
 
 /**
  * Function to convert hex values to RGB

--- a/eleventy/shortcodes/test-example.js
+++ b/eleventy/shortcodes/test-example.js
@@ -1,13 +1,13 @@
 import { blockPairedShortcode } from './utils.js'
 
-export const testExample = blockPairedShortcode(
-  /**
-   * Renders an area into which to render test examples
-   *
-   * @param {string} content - The content of the test example
-   * @returns
-   */
-  function (content) {
-    return `<div class="test-example">${content}</div>`
-  }
-)
+export const testExample = blockPairedShortcode(_testExample)
+
+/**
+ * Renders an area into which to render test examples
+ *
+ * @param {string} content - The content of the test example
+ * @returns
+ */
+function _testExample(content) {
+  return `<div class="test-example">${content}</div>`
+}

--- a/eleventy/shortcodes/video-player.js
+++ b/eleventy/shortcodes/video-player.js
@@ -2,76 +2,76 @@ import { extname } from 'node:path'
 
 import { blockShortcode } from './utils.js'
 
-export const videoPlayer = blockShortcode(
-  /**
-   * Renders a video player with the provided source(s)
-   *
-   * @param {object} options
-   * @param {string | Array<string> | {[mediaType: string]: string}} options.source - The sources of the video
-   * @param {string} [options.classes] - A space separated list of CSS classes to add to the player's `class` attribute
-   * @param {number} [options.width] - The width of the video player
-   * @param {string} [options.fallbackText] - A fallback description for the video, shown when the video is unavailable
-   * @param {boolean} [options.loop] - Whether the video should loop once played
-   * @returns {string}
-   */
-  function ({
-    source,
-    classes,
-    width = 600,
-    fallbackText = 'This video is unavailable',
-    loop = true
-  } = {}) {
-    const videoSources = []
+export const videoPlayer = blockShortcode(_videoPlayer)
 
-    if (typeof source === 'string') {
-      // Source is a string, assume it's a file path
+/**
+ * Renders a video player with the provided source(s)
+ *
+ * @param {object} options
+ * @param {string | Array<string> | {[mediaType: string]: string}} options.source - The sources of the video
+ * @param {string} [options.classes] - A space separated list of CSS classes to add to the player's `class` attribute
+ * @param {number} [options.width] - The width of the video player
+ * @param {string} [options.fallbackText] - A fallback description for the video, shown when the video is unavailable
+ * @param {boolean} [options.loop] - Whether the video should loop once played
+ * @returns {string}
+ */
+function _videoPlayer({
+  source,
+  classes,
+  width = 600,
+  fallbackText = 'This video is unavailable',
+  loop = true
+} = {}) {
+  const videoSources = []
+
+  if (typeof source === 'string') {
+    // Source is a string, assume it's a file path
+    videoSources.push({
+      file: source,
+      type: getVideoFileTypeFromFileName(source)
+    })
+  } else if (Array.isArray(source)) {
+    // Source is an array of file paths
+    source.forEach((path) => {
+      // Array item is a string, assume it's a file path
       videoSources.push({
-        file: source,
-        type: getVideoFileTypeFromFileName(source)
+        file: path,
+        type: getVideoFileTypeFromFileName(path)
       })
-    } else if (Array.isArray(source)) {
-      // Source is an array of file paths
-      source.forEach((path) => {
-        // Array item is a string, assume it's a file path
-        videoSources.push({
-          file: path,
-          type: getVideoFileTypeFromFileName(path)
-        })
+    })
+  } else if (typeof source === 'object') {
+    // Source is an object of file type : paths
+    Object.keys(source).forEach((key) => {
+      videoSources.push({
+        file: source[key],
+        type: `video/${key}`
       })
-    } else if (typeof source === 'object') {
-      // Source is an object of file type : paths
-      Object.keys(source).forEach((key) => {
-        videoSources.push({
-          file: source[key],
-          type: `video/${key}`
-        })
-      })
-    }
-
-    // Assemble sources HTML
-    const videoSourcesHtml = videoSources.map(
-      (source) => `<source src="${source.file}" type="${source.type}">`
-    )
-
-    // Create video element
-    //
-    // Video specific parameters:
-    // controls = display video playback buttons, seek bar, volume control
-    // playsinline = prevents video defaulting to fullscreen on mobile devices
-    // muted = has the video muted by default (can be unmuted with controls)
-    // loop = video repeats itself once concluded (useful for short videos)
-    return `<video
-    class="app-prose-video${classes ? ` ${classes}` : ''}"
-    width="${width}"
-    controls
-    playsinline
-    muted
-    ${loop ? 'loop' : ''}>
-    ${videoSourcesHtml.join('\n')}
-    ${fallbackText ? ` <span class="govuk-body">${fallbackText}</span>` : ''}
-  </video>`
+    })
   }
-)
+
+  // Assemble sources HTML
+  const videoSourcesHtml = videoSources.map(
+    (source) => `<source src="${source.file}" type="${source.type}">`
+  )
+
+  // Create video element
+  //
+  // Video specific parameters:
+  // controls = display video playback buttons, seek bar, volume control
+  // playsinline = prevents video defaulting to fullscreen on mobile devices
+  // muted = has the video muted by default (can be unmuted with controls)
+  // loop = video repeats itself once concluded (useful for short videos)
+  return `<video
+  class="app-prose-video${classes ? ` ${classes}` : ''}"
+  width="${width}"
+  controls
+  playsinline
+  muted
+  ${loop ? 'loop' : ''}>
+  ${videoSourcesHtml.join('\n')}
+  ${fallbackText ? ` <span class="govuk-body">${fallbackText}</span>` : ''}
+</video>`
+}
 
 function getVideoFileTypeFromFileName(fileName) {
   return 'video/' + extname(fileName)?.slice(1).toLowerCase()


### PR DESCRIPTION
Rather than merging the options ourselves, we can let JavaScript do that for us using the fact that [params can be destructured and have a default assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#destructured_parameter_with_default_value_assignment).

This could be just a personal preference, but I find using this clearly separates receiving the parameters (within the `(` and `)` of the function from what the function is doing.

While touching the shortcode params, I moved their documentation to JSDoc rather than inline comments. The call to `blockShortcode` or `pairedBlockshortcode` gets a little in the way. We could possibly:
1.  clarify thing by splitting the function of the shortcode and its export

	```js
	/**
	 * JSDoc goes there
	 */
	function _videoPlayer({ /* params go here */ } {
		//...
	}
	
	export blockShortcode(_videoPlayer)
	```

2. Call `blockShortcode` and `pairedBlockshortcode` when registering the shortcodes in `eleventy/shortcodes.js` and have the shortcode's module export plain functions. As we may have inline shortcodes in the future, this doesn't sound a great way to go as it creates distance between the code of the shortcode and whether it's block or not.

	```js
	// eleventy/shortcodes/video-player.js
	export function videoPlayer(  /* params go here */ ) {
		// ...
    }
    
    // eleventy/shortcodes.js
	import {videoPlayer} from './shortcodes/video-player.js'
	import {blockShortcode} from './shortcodes/util.js'
	//...
		eleventyConfig.addShortcode('video', blockShortcode(videoPlayer))
	//...