### PR TITLE
Use Nodemon to watch deep imports of 11ty's config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "markdown-it": "^14.1.0",
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
+        "nodemon": "^3.1.10",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "postcss": "^8.5.6",
@@ -8268,6 +8269,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/image-size": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
@@ -10074,6 +10082,58 @@
         "esm-import-transformer": "^3.0.3"
       }
     },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11319,6 +11379,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -12162,6 +12229,19 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sisteransi": {
@@ -13362,6 +13442,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -13566,6 +13656,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.11.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "name": "govuk-brand-guidelines",
   "description": "GOV.UK brand guidelines website.",
   "scripts": {
-    "start": "npm run clean && npx @11ty/eleventy --serve",
+    "start": "npm run clean && npx nodemon --watch eleventy --exec 'npx @11ty/eleventy --serve'",
     "build": "npm run clean && npx @11ty/eleventy",
     "clean": "rimraf -I _site",
     "lint:scss": "npm run lint:scss:cli -- '**/*.scss'",
@@ -46,6 +46,7 @@
     "markdown-it": "^14.1.0",
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
+    "nodemon": "^3.1.10",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "postcss": "^8.5.6",


### PR DESCRIPTION
Eleventy's configured to watch files in `eleventy` and reload the configuration. It reloads the configuration both when files imported directly by the `eleventy.config.js` change, and when the `import`s of these files change.

However, when reloading, code changes of the deeper imports are not reflected. Eleventy keeps running the code that was loaded for the first run of a deeper import. This is documented in this issue of Eleventy: https://github.com/11ty/eleventy/issues/3899

In practice, this meant that when editing the code of one of our shortcodes, Eleventy would rebuild the site, but keep using the code it initially loaded for the shortcode when it first ran, forcing us to tediously restart it manually to get the new shortcode to run.

To circumvent that, we can restart Eleventy fully by using [Nodemon](https://www.npmjs.com/package/nodemon) to watch the files loaded by Eleventy's configuration, thankfully all gathered in our `eleventy` folder. When they change, Nodemon can then restart the whole Eleventy server, in a whole new process, rather than having it keep running in the same process and just reloading its configuration.

In terms of overhead, Eleventy's reset of the configuration was already triggering a rebuild of all the files, like restarting it does. There is a little overhead from shutting down and re-starting a process, but it's barely noticeable.

Content changes (inside `src`) are left to be handled by Eleventy, which could allow us to use incremental build in the future.

## Thought

Preference went for `nodemon` rather than `chokidar-cli`, a bit by habit but also because it looks more designed around watching files for restart during development. It offers a handy `rs` command you can type in the console to restart the process without waiting for a change. Both use `chokidar` under the hood (like Eleventy) to watch the files.