### PR TITLE
Add callout shortcode

### DIFF
--- a/eleventy/shortcodes.js
+++ b/eleventy/shortcodes.js
@@ -4,6 +4,7 @@ import { swatch } from './shortcodes/swatch.js'
 import { swatchList, filterColours } from './shortcodes/swatch-list.js'
 import { testExample } from './shortcodes/test-example.js'
 import { videoPlayer } from './shortcodes/video-player.js'
+import { callout } from './shortcodes/callout.js'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
@@ -27,6 +28,7 @@ export function setupShortcodes(eleventyConfig) {
   // {% grid(param1, param2) %} Content {% endgrid %}
   // ↓
   // function grid(content, param1, param2)
+  eleventyConfig.addPairedShortcode('callout', callout)
   eleventyConfig.addPairedShortcode('grid', grid)
   eleventyConfig.addPairedShortcode('sectionHighlight', sectionHighlight)
   eleventyConfig.addPairedShortcode('testExample', testExample)

--- a/eleventy/shortcodes/callout.js
+++ b/eleventy/shortcodes/callout.js
@@ -1,0 +1,15 @@
+import { blockPairedShortcode } from './utils.js'
+
+// A simple implementation of the govuk inset text component with `app-callout`
+// added as a modifier class. Intended to save us callout govukInsetText with
+// the modifier over and over again.
+export const callout = blockPairedShortcode((content, options = {}) => {
+  const defaultOptions = {
+    classes: undefined
+  }
+  options = { ...defaultOptions, ...options }
+
+  return `<div class="govuk-inset-text app-callout${options.classes ? ` ${options.classes}` : ''}">
+    ${content}
+  </div>`
+})

--- a/src/_stylesheets/_callout.scss
+++ b/src/_stylesheets/_callout.scss
@@ -3,5 +3,5 @@
   margin: govuk-spacing(4) 0 35px;
   border-left: 2px solid govuk-colour('blue');
   border-radius: 0 3px 3px 0;
-  background-color: #e8f1f8;
+  background-color: $app-light-blue;
 }

--- a/src/_stylesheets/_callout.scss
+++ b/src/_stylesheets/_callout.scss
@@ -1,0 +1,7 @@
+// Intended to be used as a modifier on top of the govuk inset text component
+.app-callout {
+  margin: govuk-spacing(4) 0 35px;
+  border-left: 2px solid govuk-colour('blue');
+  border-radius: 0 3px 3px 0;
+  background-color: #e8f1f8;
+}

--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -12,6 +12,6 @@
 
   &.light-blue {
     color: #000000;
-    background-color: #e8f1f8;
+    background-color: $app-light-blue;
   }
 }

--- a/src/_stylesheets/_variables.scss
+++ b/src/_stylesheets/_variables.scss
@@ -1,0 +1,1 @@
+$app-light-blue: govuk-tint($govuk-brand-colour, 95%);

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -7,14 +7,18 @@
 @import 'govuk/core';
 @import 'govuk/objects';
 
+// GOV.UK Frontend components
 @import 'govuk/components/breadcrumbs';
 @import 'govuk/components/footer';
 @import 'govuk/components/header';
+@import 'govuk/components/inset-text';
 @import 'govuk/components/phase-banner';
 @import 'govuk/components/service-navigation';
 @import 'govuk/components/skip-link';
 
+// App components
 @import 'aria-current';
+@import 'callout';
 @import 'grid';
 @import 'inform-inspire';
 @import 'inline-copy';
@@ -211,19 +215,4 @@ figcaption {
 .govuk-heading-m {
   margin-bottom: 10px;
   // color: red;
-}
-
-.inset {
-  display: block;
-  margin-top: 20px;
-  margin-bottom: 35px;
-  padding: 15px;
-  border-left: 2px solid #1d70b8;
-  border-radius: 0 3px 3px 0;
-  background-color: #e8f1f8;
-}
-
-.inset p {
-  margin: 0;
-  padding: 0;
 }

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -7,6 +7,9 @@
 @import 'govuk/core';
 @import 'govuk/objects';
 
+// App variables
+@import 'variables';
+
 // GOV.UK Frontend components
 @import 'govuk/components/breadcrumbs';
 @import 'govuk/components/footer';

--- a/src/_tests/callout/index.md
+++ b/src/_tests/callout/index.md
@@ -1,0 +1,34 @@
+---
+title: Test page for the `callout` shortcode
+---
+
+## Different content types
+
+### Single paragraph
+
+{% callout %}
+This is a callout
+{% endcallout %}
+
+### Multiple paragraphs
+
+{% callout %}
+This is a paragraph
+
+This is another one
+{% endcallout %}
+
+### List
+
+{% callout %}
+- this
+- is
+- a
+- list
+{% endcallout %}
+
+## `classes` parameter
+
+{% callout {classes: "govuk-!-padding-left-9"} %}
+This is a callout
+{% endcallout %}

--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -94,11 +94,9 @@ You must make sure that the contrast ratio of colours used meets [Web Content Ac
 
 To maintain consistency across channels the colours within our palette should never be changed or altered. Exceptions to the recommendations below must be approved by the brand team.
 
-<div class="inset">
-
+{% callout %}
 Indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -132,9 +132,9 @@ The dot provides a distinctive, flexible visual thread that ties together differ
 
 To build coherence across channels, our social end frames follow the same motion behaviour as the app splash screen.
 
-<div class="inset">
-    <p class="govuk-body">This video gives a few indicative examples of how the dot could be used in motion, for illustrative purposes only.</p>
-</div>
+{% callout %}
+This video gives a few indicative examples of how the dot could be used in motion, for illustrative purposes only.
+{% endcallout %}
 
 {% grid %}
 

--- a/src/graphic-device/expression/index.md
+++ b/src/graphic-device/expression/index.md
@@ -9,9 +9,9 @@ The dot can take on different roles – guiding users through content, journeys 
 
 It should always serve a clear purpose.
 
-<div class="inset">
-    <p class="govuk-body">The examples on this page are indicative and for illustrative purposes only.</p>
-</div>
+{% callout %}
+The examples on this page are indicative and for illustrative purposes only.
+{% endcallout %}
 
 {% grid { columns: 2 } %}
 

--- a/src/graphic-device/index.md
+++ b/src/graphic-device/index.md
@@ -17,9 +17,9 @@ Used within our wordmark and as a graphic device across all GOV.UK channels, the
 </div>
 <div>
 
-<div class="inset">
-    <p class="govuk-body">The examples shown in this video are indicative and for illustrative purposes only.</p>
-</div>
+{% callout %}
+The examples shown in this video are indicative and for illustrative purposes only.
+{% endcallout %}
 
 {% video { source: [
   "./dot-animations.mp4",

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -44,11 +44,9 @@ We always lead with the wordmark as our primary brand identifier - positioning i
 
 We use the crown as a supporting element that sits below or at the end of content.
 
-<div class="inset">
-
+{% callout %}
 The examples of logo elements within the app are indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -223,11 +223,9 @@ Both logo elements have a standalone animation that can be used to add dynamism 
 
 To maintain consistency across channels the logo elements should never be changed or altered.
 
-<div class="inset">
-
+{% callout %}
 Indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -61,11 +61,9 @@ We use the crown as a supporting element that sits below or to the right of the 
 </div>
 {% endgrid %}
 
-<div class="inset">
-
+{% callout %}
 Indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 {% sectionHighlight { classes: "light-blue" } %}
 {% grid { columns: { mobile: 3, desktop: 3 } } %}

--- a/src/logo-system/web/index.md
+++ b/src/logo-system/web/index.md
@@ -20,11 +20,9 @@ To aid recognition and trust we retain the locked-up version of the crown and wo
 
 The lock-up combining the crown and wordmark is for use throughout the web experience, in moments such as the web header and footer.
 
-<div class="inset">
-
+{% callout %}
 Indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 ![Screenshot showing web header on mobile and desktop.](./web-headers-grouped.png)
 

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -24,11 +24,9 @@ Type hierarchy is key to creating content that is readable and easy to follow.
 
 Whilst there are many ways to build visual hierarchy, mixing weight and scale across tags, headlines and body copy is a simple yet effective approach.
 
-<div class="inset">
-
+{% callout %}
 Indicative examples for illustrative purposes only.
-
-</div>
+{% endcallout %}
 
 {% sectionHighlight { classes: "light-blue" } %}
 


### PR DESCRIPTION
## Change

Adds a new 'callout' shortcode which is just the [inset text component](https://design-system.service.gov.uk/components/inset-text/) with a css modifier class `app-callout`, which itself is a reimplementation of the `inset` style. Replaces all instances of `<div class="inset">...</div>` with this shortcode. No visual change intended.

The intent is to save us having to call `govukInsetText` with the modifier over and over. More details on implementation choice can be found here https://github.com/alphagov/govuk-brand-guidelines/issues/98#issuecomment-3223292950.

This additionally adds a variables stylesheet and the variable `$app-light-blue` to account for the light blue in section highlight and now callout.

Resolves https://github.com/alphagov/govuk-brand-guidelines/issues/98

## Notes and thoughts

I am open to challenges on the name.

The 35px bottom margin was pulled from the original implementation. It'd be slightly neater from a code perspective if it was 30 or 40 as this means it could fit nicely into our spacing scale via `govuk-spacing`. Would like to hear a designer's thoughts on this light challenge. Not gonna die on that hill if it's worthwhile to keep it there.