### PR TITLE
Remove rounded corners on `img-border`

### DIFF
--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -147,8 +147,6 @@ figcaption {
 .img-border {
   margin: 50px;
   overflow: hidden;
-  border: 1px solid #ffffff;
-  border-radius: 10px;
 
   > * {
     display: block;


### PR DESCRIPTION
## Change

Remove the border radius and border on `img-border`, removing the rounded corners on videos on the logo system > social page whilst retaining the spacing styling. This class is also used on the colour GOV.UK blue page on some mobile images, however the image assets themselves have rounded corners so this makes no difference besides the loss of a hard-to-see white border (challenges from designers pending and welcome).

There's some things to figure out here on the spacing around the videos on that social page but this can be handled separately.

## Visual changes

### Before

<img width="647" height="883" alt="Screenshot 2025-08-27 at 14 46 24" src="https://github.com/user-attachments/assets/dc5ee414-3721-4f0b-8fea-3471475470b4" />

### After

<img width="646" height="885" alt="Screenshot 2025-08-27 at 14 46 08" src="https://github.com/user-attachments/assets/f3edc808-72f9-4c4a-b4ac-73372c2bfaa9" />
