### PR TITLE
Add jump marks

### DIFF
--- a/eleventy/markdown.js
+++ b/eleventy/markdown.js
@@ -1,5 +1,6 @@
 import markdownIt from 'markdown-it'
 import markdownItGovuk from 'markdown-it-govuk'
+import markdownItAnchor from 'markdown-it-anchor'
 
 /**
  *  @param {import("@11ty/eleventy/UserConfig")} eleventyConfig
@@ -8,7 +9,9 @@ export function setupMarkdownCompilation(eleventyConfig) {
   const markdownConfig = markdownIt({
     html: true,
     typographer: true
-  }).use(markdownItGovuk)
+  })
+    .use(markdownItGovuk)
+    .use(markdownItAnchor)
 
   /**
    * Process a string as Markdown, treating it as a block of content (i.e. it will

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "linkinator": "^6.1.4",
         "lint-staged": "^16.1.2",
         "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^9.2.0",
         "markdown-it-govuk": "^0.6.0",
         "neostandard": "^0.12.2",
         "nodemon": "^3.1.10",
@@ -4010,6 +4011,34 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -9653,6 +9682,17 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+      "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it-govuk": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "linkinator": "^6.1.4",
     "lint-staged": "^16.1.2",
     "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "^9.2.0",
     "markdown-it-govuk": "^0.6.0",
     "neostandard": "^0.12.2",
     "nodemon": "^3.1.10",

--- a/src/colour/app/index.md
+++ b/src/colour/app/index.md
@@ -7,39 +7,51 @@ title: App
 
 The app palette contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
 
-### Blues
+Our app palette has:
+ 
+- [blues](#blues)
+- [greens](#greens)
+- [teals](#teals)
+- [purples](#purples)
+- [magentas](#magentas)
+- [reds](#reds)
+- [oranges](#oranges)
+- [yellows](#yellows)
+- [neutrals](#neutrals)
+
+### <a name="blues"></a>Blues
 
 {% swatchList { use: "app", group: "blue" } %}
 
-### Greens
+### <a name="greens"></a>Greens
 
 {% swatchList { use: "app", group: "green" } %}
 
-### Teals
+### <a name="teals"></a>Teals
 
 {% swatchList { use: "app", group: "teal" } %}
 
-### Purples
+### <a name="purples"></a>Purples
 
 {% swatchList { use: "app", group: "purple" } %}
 
-### Magentas
+### <a name="magentas"></a>Magentas
 
 {% swatchList { use: "app", group: "magenta" } %}
 
-### Reds
+### <a name="reds"></a>Reds
 
 {% swatchList { use: "app", group: "red" } %}
 
-### Oranges
+### <a name="oranges"></a>Oranges
 
 {% swatchList { use: "app", group: "orange" } %}
 
-### Yellows
+### <a name="yellows"></a>Yellows
 
 {% swatchList { use: "app", group: "yellow" } %}
 
-### Neutrals
+### <a name="neutrals"></a>Neutrals
 
 {% swatchList { use: "app", group: "neutral" } %}
 

--- a/src/colour/app/index.md
+++ b/src/colour/app/index.md
@@ -8,7 +8,7 @@ title: App
 The app palette contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
 
 Our app palette has:
- 
+
 - [blues](#blues)
 - [greens](#greens)
 - [teals](#teals)
@@ -19,39 +19,39 @@ Our app palette has:
 - [yellows](#yellows)
 - [neutrals](#neutrals)
 
-### <a name="blues"></a>Blues
+### Blues
 
 {% swatchList { use: "app", group: "blue" } %}
 
-### <a name="greens"></a>Greens
+### Greens
 
 {% swatchList { use: "app", group: "green" } %}
 
-### <a name="teals"></a>Teals
+### Teals
 
 {% swatchList { use: "app", group: "teal" } %}
 
-### <a name="purples"></a>Purples
+### Purples
 
 {% swatchList { use: "app", group: "purple" } %}
 
-### <a name="magentas"></a>Magentas
+### Magentas
 
 {% swatchList { use: "app", group: "magenta" } %}
 
-### <a name="reds"></a>Reds
+### Reds
 
 {% swatchList { use: "app", group: "red" } %}
 
-### <a name="oranges"></a>Oranges
+### Oranges
 
 {% swatchList { use: "app", group: "orange" } %}
 
-### <a name="yellows"></a>Yellows
+### Yellows
 
 {% swatchList { use: "app", group: "yellow" } %}
 
-### <a name="neutrals"></a>Neutrals
+### Neutrals
 
 {% swatchList { use: "app", group: "neutral" } %}
 

--- a/src/colour/print/index.md
+++ b/src/colour/print/index.md
@@ -7,38 +7,50 @@ title: Print
 
 Use these colours for printed materials like documents, or in custom formats where appropriate.
 
-### Blues
+Our print palette has:
+ 
+- [blues](#blues)
+- [greens](#greens)
+- [teals](#teals)
+- [purples](#purples)
+- [magentas](#magentas)
+- [reds](#reds)
+- [oranges](#oranges)
+- [yellows](#yellows)
+- [neutrals](#neutrals)
+
+### <a name="blues"></a>Blues
 
 {% swatchList { use: "print", group: "blue" } %}
 
-### Greens
+### <a name="greens"></a>Greens
 
 {% swatchList { use: "print", group: "green" } %}
 
-### Teals
+### <a name="teals"></a>Teals
 
 {% swatchList { use: "print", group: "teal" } %}
 
-### Purples
+### <a name="purples"></a>Purples
 
 {% swatchList { use: "print", group: "purple" } %}
 
-### Magentas
+### <a name="magentas"></a>Magentas
 
 {% swatchList { use: "print", group: "magenta" } %}
 
-### Reds
+### <a name="reds"></a>Reds
 
 {% swatchList { use: "print", group: "red" } %}
 
-### Oranges
+### <a name="oranges"></a>Oranges
 
 {% swatchList { use: "print", group: "orange" } %}
 
-### Yellows
+### <a name="yellows"></a>Yellows
 
 {% swatchList { use: "print", group: "yellow" } %}
 
-### Neutrals
+### <a name="neutrals"></a>Neutrals
 
 {% swatchList { use: "print", group: "neutral" } %}

--- a/src/colour/print/index.md
+++ b/src/colour/print/index.md
@@ -8,7 +8,7 @@ title: Print
 Use these colours for printed materials like documents, or in custom formats where appropriate.
 
 Our print palette has:
- 
+
 - [blues](#blues)
 - [greens](#greens)
 - [teals](#teals)
@@ -19,38 +19,38 @@ Our print palette has:
 - [yellows](#yellows)
 - [neutrals](#neutrals)
 
-### <a name="blues"></a>Blues
+### Blues
 
 {% swatchList { use: "print", group: "blue" } %}
 
-### <a name="greens"></a>Greens
+### Greens
 
 {% swatchList { use: "print", group: "green" } %}
 
-### <a name="teals"></a>Teals
+### Teals
 
 {% swatchList { use: "print", group: "teal" } %}
 
-### <a name="purples"></a>Purples
+### Purples
 
 {% swatchList { use: "print", group: "purple" } %}
 
-### <a name="magentas"></a>Magentas
+### Magentas
 
 {% swatchList { use: "print", group: "magenta" } %}
 
-### <a name="reds"></a>Reds
+### Reds
 
 {% swatchList { use: "print", group: "red" } %}
 
-### <a name="oranges"></a>Oranges
+### Oranges
 
 {% swatchList { use: "print", group: "orange" } %}
 
-### <a name="yellows"></a>Yellows
+### Yellows
 
 {% swatchList { use: "print", group: "yellow" } %}
 
-### <a name="neutrals"></a>Neutrals
+### Neutrals
 
 {% swatchList { use: "print", group: "neutral" } %}

--- a/src/colour/social/index.md
+++ b/src/colour/social/index.md
@@ -8,7 +8,7 @@ title: Social
 The social palette requires moments of increased brand expression and flex and therefore contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
 
 Our social palette has:
- 
+
 - [blues](#blues)
 - [greens](#greens)
 - [teals](#teals)
@@ -19,39 +19,39 @@ Our social palette has:
 - [yellows](#yellows)
 - [neutrals](#neutrals)
 
-### <a name="blues"></a>Blues
+### Blues
 
 {% swatchList { use: "social", group: "blue" } %}
 
-### <a name="greens"></a>Greens
+### Greens
 
 {% swatchList { use: "social", group: "green" } %}
 
-### <a name="teals"></a>Teals
+### Teals
 
 {% swatchList { use: "social", group: "teal" } %}
 
-### <a name="purples"></a>Purples
+### Purples
 
 {% swatchList { use: "social", group: "purple" } %}
 
-### <a name="magentas"></a>Magentas
+### Magentas
 
 {% swatchList { use: "social", group: "magenta" } %}
 
-### <a name="reds"></a>Reds
+### Reds
 
 {% swatchList { use: "social", group: "red" } %}
 
-### <a name="oranges"></a>Oranges
+### Oranges
 
 {% swatchList { use: "social", group: "orange" } %}
 
-### <a name="yellows"></a>Yellows
+### Yellows
 
 {% swatchList { use: "social", group: "yellow" } %}
 
-### <a name="neutrals"></a>Neutrals
+### Neutrals
 
 {% swatchList { use: "social", group: "neutral" } %}
 

--- a/src/colour/social/index.md
+++ b/src/colour/social/index.md
@@ -7,39 +7,51 @@ title: Social
 
 The social palette requires moments of increased brand expression and flex and therefore contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
 
-### Blues
+Our social palette has:
+ 
+- [blues](#blues)
+- [greens](#greens)
+- [teals](#teals)
+- [purples](#purples)
+- [magentas](#magentas)
+- [reds](#reds)
+- [oranges](#oranges)
+- [yellows](#yellows)
+- [neutrals](#neutrals)
+
+### <a name="blues"></a>Blues
 
 {% swatchList { use: "social", group: "blue" } %}
 
-### Greens
+### <a name="greens"></a>Greens
 
 {% swatchList { use: "social", group: "green" } %}
 
-### Teals
+### <a name="teals"></a>Teals
 
 {% swatchList { use: "social", group: "teal" } %}
 
-### Purples
+### <a name="purples"></a>Purples
 
 {% swatchList { use: "social", group: "purple" } %}
 
-### Magentas
+### <a name="magentas"></a>Magentas
 
 {% swatchList { use: "social", group: "magenta" } %}
 
-### Reds
+### <a name="reds"></a>Reds
 
 {% swatchList { use: "social", group: "red" } %}
 
-### Oranges
+### <a name="oranges"></a>Oranges
 
 {% swatchList { use: "social", group: "orange" } %}
 
-### Yellows
+### <a name="yellows"></a>Yellows
 
 {% swatchList { use: "social", group: "yellow" } %}
 
-### Neutrals
+### <a name="neutrals"></a>Neutrals
 
 {% swatchList { use: "social", group: "neutral" } %}
 

--- a/src/colour/web/index.md
+++ b/src/colour/web/index.md
@@ -11,47 +11,61 @@ To reference colours from the palette directly you should use the `govuk-colour`
 
 Avoid using the palette colours if there is a Sass variable that is designed for your context. For example, if you are styling the error state of a component you should use the `$govuk-error-colour` Sass variable rather than `govuk-colour("red")`.
 
-### Blues
+Our web palette has:
+ 
+- [blues](#blues)
+- [greens](#greens)
+- [teals](#teals)
+- [purples](#purples)
+- [magentas](#magentas)
+- [reds](#reds)
+- [oranges](#oranges)
+- [yellows](#yellows)
+- [browns](#browns)
+- [neutrals](#neutrals)
+- [web functional colours](#web-functional-colours)
+
+### <a name="blues"></a>Blues
 
 {% swatchList { use: "web", group: "blue" } %}
 
-### Greens
+### <a name="greens"></a>Greens
 
 {% swatchList { use: "web", group: "green" } %}
 
-### Teals
+### <a name="teals"></a>Teals
 
 {% swatchList { use: "web", group: "teal" } %}
 
-### Purples
+### <a name="purples"></a>Purples
 
 {% swatchList { use: "web", group: "purple" } %}
 
-### Magentas
+### <a name="magentas"></a>Magentas
 
 {% swatchList { use: "web", group: "magenta" } %}
 
-### Reds
+### <a name="reds"></a>Reds
 
 {% swatchList { use: "web", group: "red" } %}
 
-### Oranges
+### <a name="oranges"></a>Oranges
 
 {% swatchList { use: "web", group: "orange" } %}
 
-### Yellows
+### <a name="yellows"></a>Yellows
 
 {% swatchList { use: "web", group: "yellow" } %}
 
-### Browns
+### <a name="browns"></a>Browns
 
 {% swatchList { use: "web", group: "brown" } %}
 
-### Neutrals
+### <a name="neutrals"></a>Neutrals
 
 {% swatchList { use: "web", group: "neutral" } %}
 
-### Web functional colours
+### <a name="web-functional-colours"></a>Web functional colours
 
 If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather than `#1d70b8`.
 

--- a/src/colour/web/index.md
+++ b/src/colour/web/index.md
@@ -12,7 +12,7 @@ To reference colours from the palette directly you should use the `govuk-colour`
 Avoid using the palette colours if there is a Sass variable that is designed for your context. For example, if you are styling the error state of a component you should use the `$govuk-error-colour` Sass variable rather than `govuk-colour("red")`.
 
 Our web palette has:
- 
+
 - [blues](#blues)
 - [greens](#greens)
 - [teals](#teals)
@@ -25,47 +25,47 @@ Our web palette has:
 - [neutrals](#neutrals)
 - [web functional colours](#web-functional-colours)
 
-### <a name="blues"></a>Blues
+### Blues
 
 {% swatchList { use: "web", group: "blue" } %}
 
-### <a name="greens"></a>Greens
+### Greens
 
 {% swatchList { use: "web", group: "green" } %}
 
-### <a name="teals"></a>Teals
+### Teals
 
 {% swatchList { use: "web", group: "teal" } %}
 
-### <a name="purples"></a>Purples
+### Purples
 
 {% swatchList { use: "web", group: "purple" } %}
 
-### <a name="magentas"></a>Magentas
+### Magentas
 
 {% swatchList { use: "web", group: "magenta" } %}
 
-### <a name="reds"></a>Reds
+### Reds
 
 {% swatchList { use: "web", group: "red" } %}
 
-### <a name="oranges"></a>Oranges
+### Oranges
 
 {% swatchList { use: "web", group: "orange" } %}
 
-### <a name="yellows"></a>Yellows
+### Yellows
 
 {% swatchList { use: "web", group: "yellow" } %}
 
-### <a name="browns"></a>Browns
+### Browns
 
 {% swatchList { use: "web", group: "brown" } %}
 
-### <a name="neutrals"></a>Neutrals
+### Neutrals
 
 {% swatchList { use: "web", group: "neutral" } %}
 
-### <a name="web-functional-colours"></a>Web functional colours
+### Web functional colours
 
 If you are using GOV.UK Frontend or the GOV.UK Prototype Kit, use the [Sass variables](https://frontend.design-system.service.gov.uk/sass-api-reference/#colours) provided rather than copying the hexadecimal (hex) colour values. For example, use `$govuk-brand-colour` rather than `#1d70b8`.
 

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -96,7 +96,7 @@ As this is a small use application of the logo elements, we use the enlarged cro
 {% endgrid %}
 {% endsectionHighlight %}
 
-### <a name="app-icon-suite"></a>App icon suite
+### App icon suite
 
 As the family of GOV.UK applications grows, the need for a consistent approach to app icon design is necessary.
 

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -13,11 +13,11 @@ Lock-ups help show the relationship between GOV.UK and the service, channel or d
 
 We have five versions:
 
-1. Horizontal
-2. Horizontal with crown
-3. Stacked (web)
-4. Stacked (apps)
-5. Stacked with crown
+1. [Horizontal](#horizontal)
+2. [Horizontal with crown](#horizontal-with-crown)
+3. [Stacked for web](#stacked-for-web)
+4. [Stacked for apps](#stacked-for-app)
+5. [Stacked with crown](#stacked-with-crown)
 
 To keep the brand consistent, use each version exactly as shown – do not resize, reposition or remove any part.
 
@@ -56,7 +56,7 @@ In both horizontal and stacked lock-ups, the space between the wordmark and prod
 
 <div class="app-top-border">
 
-### Horizontal
+### <a name="horizontal"></a>Horizontal
 
 Product name spacing on horizontal and stacked lock-ups should be proportionate to the type size.
 
@@ -71,7 +71,7 @@ On 14.2pt type, letter spacing should be -0.21 pixels.
 
 <div class="app-top-border">
 
-### Horizontal with crown
+### <a name="horizontal-with-crown"></a>Horizontal with crown
 
 Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots or 7px spacing on web.
 
@@ -84,7 +84,7 @@ Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots 
 
 <div class="app-top-border">
 
-### Stacked for web
+### <a name="stacked-for-web"></a>Stacked for web
 
 Product name on stacked lock-ups should be aligned left to GOV.UK wordmark.
 
@@ -99,7 +99,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 </div>
 <div class="app-top-border">
 
-### Stacked for app
+### <a name="stacked-for-app"></a>Stacked for app
 
 Product name on stacked lock-ups should be centre to GOV.UK wordmark.
 
@@ -113,7 +113,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 </div>
 <div class="app-top-border">
 
-### Stacked with crown
+### <a name="stacked-with-crown"></a>Stacked with crown
 
 Product name on stacked lock-ups should be aligned left to crown.
 

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -21,7 +21,7 @@ We have five versions:
 
 To keep the brand consistent, use each version exactly as shown – do not resize, reposition or remove any part.
 
-The diagrams on this page show how to space the wordmark and text in a lock-up. Use the width of the dot in the GOV.UK wordmark to set the spacing. 
+The diagrams on this page show how to space the wordmark and text in a lock-up. Use the width of the dot in the GOV.UK wordmark to set the spacing.
 
 In both horizontal and stacked lock-ups, the space between the wordmark and product name should be the width of the dot.
 
@@ -56,7 +56,7 @@ In both horizontal and stacked lock-ups, the space between the wordmark and prod
 
 <div class="app-top-border">
 
-### <a name="horizontal"></a>Horizontal
+### Horizontal
 
 Product name spacing on horizontal and stacked lock-ups should be proportionate to the type size.
 
@@ -71,7 +71,7 @@ On 14.2pt type, letter spacing should be -0.21 pixels.
 
 <div class="app-top-border">
 
-### <a name="horizontal-with-crown"></a>Horizontal with crown
+### Horizontal with crown
 
 Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots or 7px spacing on web.
 
@@ -84,7 +84,7 @@ Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots 
 
 <div class="app-top-border">
 
-### <a name="stacked-for-web"></a>Stacked for web
+### Stacked for web
 
 Product name on stacked lock-ups should be aligned left to GOV.UK wordmark.
 
@@ -99,7 +99,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 </div>
 <div class="app-top-border">
 
-### <a name="stacked-for-app"></a>Stacked for app
+### Stacked for app
 
 Product name on stacked lock-ups should be centre to GOV.UK wordmark.
 
@@ -113,7 +113,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 </div>
 <div class="app-top-border">
 
-### <a name="stacked-with-crown"></a>Stacked with crown
+### Stacked with crown
 
 Product name on stacked lock-ups should be aligned left to crown.
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -9,7 +9,7 @@ Our wordmark has been redrawn, elevating the dot into a position that signifies 
 
 As our primary identifier, the GOV.UK wordmark should be used in all applications of the logo.
 
-The exception to this rule is the GOV.UK website. See the [Web – Logo system page](/logo-system/web/).
+[The exception to this rule is the GOV.UK website](/logo-system/web/).
 
 {% sectionHighlight %}
 
@@ -24,7 +24,7 @@ The exception to this rule is the GOV.UK website. See the [Web – Logo system p
 
 As our primary identifier, the GOV.UK wordmark should be used in all applications of the logo.
 
-The exception to this rule is the GOV.UK website. See the [Web – Logo system page](/logo-system/web/).
+[The exception to this rule is the GOV.UK website](/logo-system/web/).
 
 {% sectionHighlight %}
 


### PR DESCRIPTION
This PR adds MVP jump marks to a few pages that require more navigation aids due to content length.

Related to https://github.com/alphagov/govuk-brand-guidelines/pull/44 which will also address the issue.

Some previous discussion in https://github.com/alphagov/govuk-brand-guidelines/pull/122 added:

@mia-allers-gds 

> On the links, do you think the links should go to H3s, or H2s? H2s would make the contents list shorter and possibly more useful across the site. I appreciate the list of swatches is very long, though. I've been working on a layout to hopefully mitigate at least some of the length of the swatch list.