### PR TITLE
Clean up section highlight CSS

### DIFF
--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -1,8 +1,10 @@
 .app-section-highlight {
+  border-radius: 3px;
   color: govuk-colour('white');
   background-color: govuk-colour('blue');
-  @include govuk-responsive-padding(3);
-  @include govuk-responsive-margin(5, $direction: 'bottom');
+  @include govuk-responsive-padding(6);
+  @include govuk-responsive-margin(8, $direction: 'top');
+  @include govuk-responsive-margin(8, $direction: 'bottom');
 
   [class^='govuk-heading'],
   [class^='govuk-body'],
@@ -10,8 +12,17 @@
     color: inherit;
   }
 
-  &.light-blue {
-    color: #000000;
-    background-color: $app-light-blue;
+  p:last-child {
+    margin-bottom: 0;
   }
+}
+
+.app-section-highlight--light-blue {
+  color: govuk-colour('black');
+  background-color: $app-light-blue;
+}
+
+.app-section-highlight--light-grey {
+  color: govuk-colour('black');
+  background-color: govuk-colour('light-grey');
 }

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -125,21 +125,3 @@
   border-top: 1px solid #ffffff;
 }
 
-// Section highlight adjustments
-.app-section-highlight {
-  margin-top: 50px;
-  margin-bottom: 50px;
-  padding: 30px 30px 10px;
-  border-radius: 3px;
-}
-
-// Light background uses 90% blue tint instead of 95%
-.light-blue {
-  color: #000000;
-  background-color: #e8f1f8;
-}
-
-.light-grey {
-  color: #000000;
-  background-color: #f3f3f3;
-}

--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -39,7 +39,7 @@ We lead with the Primary Blue and Accent Teal across all GOV.UK channels. From t
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
 <div>

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -238,7 +238,7 @@ Indicative examples for illustrative purposes only.
 <p aria-hidden="true" class="govuk-heading-s app-inform-inspire__inspire">Inspire</p>
 </div>
 
-{% sectionHighlight {classes: "light-blue" } %}
+{% sectionHighlight {classes: "app-section-highlight--light-blue" } %}
 
 ## Static dot examples
 

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -78,7 +78,7 @@ The GOV.UK app icon should follow the same principle, leading with the wordmark 
 
 As this is a small use application of the logo elements, we use the enlarged crown size to maximise legibility and recognition.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div class="flex-center">

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -25,7 +25,7 @@ The diagrams on this page show how to space the wordmark and text in a lock-up. 
 
 In both horizontal and stacked lock-ups, the space between the wordmark and product name should be the width of the dot.
 
-{% sectionHighlight { classes: "light-grey" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-grey" } %}
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div class="flex-end">

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -65,7 +65,7 @@ We use the crown as a supporting element that sits below or to the right of the 
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 {% grid { columns: { mobile: 3, desktop: 3 } } %}
 
 ![Mock-up of the GOV.UK channel page on YouTube.](./youtube-example.png)
@@ -81,7 +81,7 @@ Indicative examples for illustrative purposes only.
 
 Social end frames can be used at the end of animated or filmed content. They incorporate both the wordmark and crown and act as a branded sign-off.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 <div>
 

--- a/src/logo-system/web/index.md
+++ b/src/logo-system/web/index.md
@@ -26,7 +26,7 @@ Indicative examples for illustrative purposes only.
 
 ![Screenshot showing web header on mobile and desktop.](./web-headers-grouped.png)
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 We also use the crown as a supporting element within the footer at the end of content.
 

--- a/src/typography/app/index.md
+++ b/src/typography/app/index.md
@@ -9,7 +9,7 @@ GDS Transport is our primary brand typeface.
 
 Using it within our apps can provide significant advantages, particularly in strengthening brand recognition and creating a cohesive user experience across platforms and channels.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 Whilst there may be cases where it is not possible, we should always try to use GDS Transport where possible.
 
@@ -22,7 +22,7 @@ Whilst there may be cases where it is not possible, we should always try to use 
 
 It may not always be possible to use GDS Transport, such as within native operating system environments. In such cases, it is recommended to use the platform’s default system typeface to ensure consistency, performance, and accessibility.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 For example, on Apple (iOS, macOS) use SF Pro, the system font designed for optimal legibility and integration with Apple’s UI.
 

--- a/src/typography/index.md
+++ b/src/typography/index.md
@@ -39,7 +39,7 @@ GDS transport consists of two weights; **Light** and **Bold**.
 
 GDS Transport offers a wide range of glyph support. It includes a comprehensive selection of letters, numerals, punctuation, and special symbols, making it suitable for various levels of communications.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 GDS Transport Light
 

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -9,7 +9,7 @@ GDS Transport is our primary brand typeface.
 
 Using it within our social channels can provide significant advantages, particularly in strengthening brand recognition and creating a cohesive user experience across platforms and channels.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 Whilst there may be cases where it is not possible, we should always try to use GDS Transport where possible.
 
@@ -28,7 +28,7 @@ Whilst there are many ways to build visual hierarchy, mixing weight and scale ac
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 ![TODO](./type-hierarchy.png)
 
@@ -148,7 +148,7 @@ There will be occasions where GDS Transport is not available for use, such as wi
 
 Where standard system fonts are available, Helvetica Neue or Arial should be used.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 In cases where system fonts are unavailable, the closest replacement should be used. This should always be a sans serif, low contrast typeface with a focus on accessibility.
 

--- a/src/typography/web/index.md
+++ b/src/typography/web/index.md
@@ -7,7 +7,7 @@ title: Web
 
 If your service is on the service.gov.uk subdomain you must use the GDS Transport font.
 
-{% sectionHighlight { classes: "light-blue" } %}
+{% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
 For in depth guidance on how to correctly apply typography within the web channel, refer to the [Design System Guidelines](https://design-system.service.gov.uk/styles/typeface/).
 


### PR DESCRIPTION
Clean up the CSS around the section highlight component.

Closes #102.

## Changes
- Moves all the code into the `_section-highlight.scss` partial.
- Renames the `.light-grey` and `.light-blue` classes to be namespaced to the section highlight.
  - They're now `.app-section-highlight--light-grey` and `.app-section-highlight--light-blue` respectively.
- Changes references to colours to use GOV.UK Frontend's colour function.
- Changes the margins and padding to use GOV.UK Frontend's responsive mixins.
- Removes the reduction to the bottom padding.
- Added style to remove the bottom margin from the last paragraph within a section.
  - The above two things essentially have the same end result of reducing excess negative space at the bottom of a section, but the margin route seems more robust as it doesn't remove padding where there is no benefit to doing so. 