### PR TITLE
Move global element styling under `app-prose`

### DIFF
--- a/eleventy/media.js
+++ b/eleventy/media.js
@@ -22,7 +22,6 @@ export function setupMedia(eleventyConfig) {
     // Attributes on the output HTML
     htmlOptions: {
       imgAttributes: {
-        class: 'app-prose-image',
         loading: 'lazy',
         decoding: 'async'
       },

--- a/eleventy/shortcodes/video-player.js
+++ b/eleventy/shortcodes/video-player.js
@@ -90,9 +90,9 @@ export const videoPlayer = blockShortcode((options = {}) => {
   // playsinline = prevents video defaulting to fullscreen on mobile devices
   // muted = has the video muted by default (can be unmuted with controls)
   // loop = video repeats itself once concluded (useful for short videos)
-  return `<video
-    class="app-prose-video${options.classes ? ` ${options.classes}` : ''}"
-    width="${playerWidth}"
+
+  return `<video${options.classes ? ` class="${options.classes}"` : ''}
+    width="${options.width}"
     height="${playerHeight}"
     controls
     playsinline

--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -80,7 +80,7 @@
   #}
 {% endblock %}
 
-{% set mainClasses = 'govuk-grid-column-two-thirds app-main-wrapper' %}
+{% set mainClasses = 'govuk-grid-column-two-thirds app-main-wrapper app-prose' %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{title}}</h1>

--- a/src/_stylesheets/_prose.scss
+++ b/src/_stylesheets/_prose.scss
@@ -8,3 +8,24 @@
   width: auto;
   max-height: 90vh;
 }
+
+.app-prose code {
+  padding-right: govuk-spacing(1);
+  padding-left: govuk-spacing(1);
+  border: 1px solid govuk-colour('mid-grey');
+  border-radius: 3px;
+  background-color: govuk-colour('light-grey');
+  font-family: ui-monospace, monospace;
+
+  // Monospace fonts tend to look larger than the surrounding text due to having
+  // exaggerated x-heights, making them smaller makes text look more uniform.
+  // Setting using a keyword instead of a fixed size as headings may also
+  // contain inline code snippets.
+  font-size: smaller;
+}
+
+.app-prose pre code {
+  display: block;
+  padding: govuk-spacing(1);
+  @include govuk-font-size(16);
+}

--- a/src/_stylesheets/_prose.scss
+++ b/src/_stylesheets/_prose.scss
@@ -9,6 +9,17 @@
   max-height: 90vh;
 }
 
+.app-prose figure {
+  margin: 0;
+}
+
+.app-prose figcaption {
+  @include govuk-typography-common;
+
+  font-size: 16px;
+  text-align: center;
+}
+
 .app-prose code {
   padding-right: govuk-spacing(1);
   padding-left: govuk-spacing(1);

--- a/src/_stylesheets/_prose.scss
+++ b/src/_stylesheets/_prose.scss
@@ -1,0 +1,10 @@
+.app-prose img,
+.app-prose video {
+  max-width: 100%;
+  height: auto;
+}
+
+.app-prose video {
+  width: auto;
+  max-height: 90vh;
+}

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -58,31 +58,6 @@
   font-size: larger;
 }
 
-pre code,
-.app-code {
-  border: 1px solid govuk-colour('mid-grey');
-  border-radius: 3px;
-  background-color: govuk-colour('light-grey');
-  font-family: ui-monospace, monospace;
-
-  // Monospace fonts tend to look larger than the surrounding text due to having
-  // exaggerated x-heights, making them smaller makes text look more uniform.
-  // Setting using a keyword instead of a fixed size as headings may also
-  // contain inline code snippets.
-  font-size: smaller;
-}
-
-pre code {
-  display: block;
-  padding: govuk-spacing(1);
-  @include govuk-font-size(16);
-}
-
-.app-code--inline {
-  padding-right: govuk-spacing(1);
-  padding-left: govuk-spacing(1);
-}
-
 .app-meta-info {
   color: #484949;
 }

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -67,17 +67,6 @@
   border-top: 1px solid #16548a;
 }
 
-figure {
-  margin: 0;
-}
-
-figcaption {
-  @include govuk-typography-common;
-
-  font-size: 16px;
-  text-align: center;
-}
-
 // Flexbox for arranging things inside the grid
 // Centering elements in flex
 .flex-center {

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -107,7 +107,6 @@
 .img-border {
   margin: 50px;
   overflow: hidden;
-
 }
 
 // Grid adjustments
@@ -143,9 +142,4 @@
 .light-grey {
   color: #000000;
   background-color: #f3f3f3;
-}
-// Typography
-.govuk-heading-m {
-  margin-bottom: 10px;
-  // color: red;
 }

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -19,6 +19,8 @@
 @import 'govuk/components/service-navigation';
 @import 'govuk/components/skip-link';
 
+@import 'prose';
+
 // App components
 @import 'aria-current';
 @import 'callout';
@@ -49,17 +51,6 @@
   @include govuk-media-query($from: tablet) {
     display: none;
   }
-}
-
-.app-prose-image,
-.app-prose-video {
-  max-width: 100%;
-  height: auto;
-}
-
-.app-prose-video {
-  width: auto;
-  max-height: 90vh;
 }
 
 .app-size-recommendation {

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -108,11 +108,6 @@
   margin: 50px;
   overflow: hidden;
 
-  > * {
-    display: block;
-    margin-bottom: 0;
-    line-height: 0;
-  }
 }
 
 // Grid adjustments
@@ -149,29 +144,6 @@
   color: #000000;
   background-color: #f3f3f3;
 }
-
-// Scale, float images
-// container for scaling
-.scale {
-  display: inline-block;
-  // border: 1px solid red;
-}
-
-// image alignment
-.right img {
-  float: right;
-}
-
-// image width
-.width-80 img {
-  max-width: 80%;
-}
-
-.edge {
-  margin-right: -30px;
-  margin-bottom: -10px;
-}
-
 // Typography
 .govuk-heading-m {
   margin-bottom: 10px;

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -197,7 +197,7 @@ Indicative examples for illustrative purposes only.
 <figure class="app-figure">
     <div class="app-figure-container">
         <picture>
-            <img class="app-prose-image" src="./video-thumb-get-help.png" alt="A video thumbnail for 'Get help with registering a death'. Title is shown within a simple blue circle graphic on a blue background.">
+            <img src="./video-thumb-get-help.png" alt="A video thumbnail for 'Get help with registering a death'. Title is shown within a simple blue circle graphic on a blue background.">
         </picture>
         <figcaption class="app-figure__caption">
             <p class="govuk-body">Get help with...</p>
@@ -207,7 +207,7 @@ Indicative examples for illustrative purposes only.
 <figure class="app-figure">
     <div class="app-figure-container"> 
         <picture>
-            <img class="app-prose-image" src="./video-thumb-60s.png" alt="A video thumbnail showing a title overlay for 'Check a vehicle before you buy', includes an icon of a small clock that resembles the dot.">
+            <img src="./video-thumb-60s.png" alt="A video thumbnail showing a title overlay for 'Check a vehicle before you buy', includes an icon of a small clock that resembles the dot.">
         </picture>
         <figcaption class="app-figure__caption">
             <p class="govuk-body">60s guides</p>
@@ -217,7 +217,7 @@ Indicative examples for illustrative purposes only.
 <figure class="app-figure">
     <div class="app-figure-container">
         <picture>
-            <img class="app-prose-image" src="./video-thumb-step.png" alt="A video thumbnail for 'How to apple for a Visa'. Title is shown on light blue background beside an illustration of travel documents incorporating the dot.">
+            <img src="./video-thumb-step.png" alt="A video thumbnail for 'How to apple for a Visa'. Title is shown on light blue background beside an illustration of travel documents incorporating the dot.">
         </picture>
         <figcaption class="app-figure__caption">
             <p class="govuk-body">Step-by-step guides</p>
@@ -227,7 +227,7 @@ Indicative examples for illustrative purposes only.
 <figure class="app-figure">
     <div class="app-figure-container">
         <picture>
-            <img class="app-prose-image" src="./video-thumb-influencer.png" alt="A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a background, which is a purple circular title graphic.">
+            <img src="./video-thumb-influencer.png" alt="A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a background, which is a purple circular title graphic.">
         </picture>
         <figcaption class="app-figure__caption">
             <p class="govuk-body">Influencer/presenter</p>

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -194,42 +194,42 @@ Indicative examples for illustrative purposes only.
 <p class="govuk-visually-hidden">From most infomative to most inspiring</p>
 <p class="govuk-heading-s app-inform-inspire__inform" aria-hidden="true">Inform</p>
 
-<figure class="app-figure">
+<figure>
     <div class="app-figure-container">
         <picture>
             <img src="./video-thumb-get-help.png" alt="A video thumbnail for 'Get help with registering a death'. Title is shown within a simple blue circle graphic on a blue background.">
         </picture>
-        <figcaption class="app-figure__caption">
+        <figcaption>
             <p class="govuk-body">Get help with...</p>
         </figcaption>
     </div>
 </figure>
-<figure class="app-figure">
+<figure>
     <div class="app-figure-container"> 
         <picture>
             <img src="./video-thumb-60s.png" alt="A video thumbnail showing a title overlay for 'Check a vehicle before you buy', includes an icon of a small clock that resembles the dot.">
         </picture>
-        <figcaption class="app-figure__caption">
+        <figcaption>
             <p class="govuk-body">60s guides</p>
         </figcaption>
     </div>
 </figure>
-<figure class="app-figure">
+<figure>
     <div class="app-figure-container">
         <picture>
             <img src="./video-thumb-step.png" alt="A video thumbnail for 'How to apple for a Visa'. Title is shown on light blue background beside an illustration of travel documents incorporating the dot.">
         </picture>
-        <figcaption class="app-figure__caption">
+        <figcaption>
             <p class="govuk-body">Step-by-step guides</p>
         </figcaption>
     </div>
 </figure>
-<figure class="app-figure">
+<figure>
     <div class="app-figure-container">
         <picture>
             <img src="./video-thumb-influencer.png" alt="A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a background, which is a purple circular title graphic.">
         </picture>
-        <figcaption class="app-figure__caption">
+        <figcaption>
             <p class="govuk-body">Influencer/presenter</p>
         </figcaption>
     </div>

--- a/src/graphic-device/index.md
+++ b/src/graphic-device/index.md
@@ -13,7 +13,7 @@ Used within our wordmark and as a graphic device across all GOV.UK channels, the
 {% grid %}
 
 <div>
-    <img src="./the-dot.svg" alt="The GOV.UK wordmark, with an arrow that points to the dot." class="app-prose-image" loading="lazy" decoding="async" width="669" height="180" style="padding: 30px; max-width: calc(100% - 60px); background-color: #1d70b8;">
+    <img src="./the-dot.svg" alt="The GOV.UK wordmark, with an arrow that points to the dot." loading="lazy" decoding="async" width="669" height="180" style="padding: 30px; max-width: calc(100% - 60px); background-color: #1d70b8;">
 </div>
 <div>
 

--- a/src/typography/index.md
+++ b/src/typography/index.md
@@ -25,11 +25,8 @@ The Government Digital Service adapted it in 2012 for digital use, bringing the 
 
 Using GDS Transport makes GOV.UK easier to recognise and information easier to read on any device.
 
-<div class="scale width-80 right edge">
-
 ![TODO](./transport-font.svg)
 
-</div>
 {% endsectionHighlight %}
 
 ### Weights


### PR DESCRIPTION
## Change

Adds a prose sass partial, including an `app-prose` class attached to the `main` element, and moves common html element-level styling under there. This re-implements the design system websites' `app-prose-scope` class solution for in-content markdown elements.

Specific changes:

- Deleting `app-prose-image` and `app-prose-video` in favour of styling on `img` and `video` under prose
- Deleting reference in styling to `app-code` and `app-code--inline` in favour of prose styling on `code` and `pre code`
- Moving `figure` and `figcaption` styling under prose
- Getting rid of specific positional styling for an image on the typography landing page
- Getting rid of a global styling rule setting the bottom margin of all `govuk-heading-m`'s

No visual changes intended

Resolves https://github.com/alphagov/govuk-brand-guidelines/issues/99

## Notes

The fairly complex inform/inspire graphic element on the dot use examples page needs cleaning up but this can be done as part of https://github.com/alphagov/govuk-brand-guidelines/issues/121

There are 2 rules in the main stylesheet I didn't address:

- `img-fit`
- 'img-scale'

Following a chat with @mia-allers-gds and @hazalarpalikli I've left these for now until a few strategic design decisions are made as part of https://github.com/alphagov/govuk-brand-guidelines/issues/114.