### PR TITLE
Refactor top border classes

### DIFF
--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -15,14 +15,25 @@
   p:last-child {
     margin-bottom: 0;
   }
+
+  .app-top-border {
+    --app-top-border-colour: #{govuk-colour('white')};
+  }
+}
+
+.app-section-highlight--light-blue,
+.app-section-highlight--light-grey {
+  color: govuk-colour('black');
+
+  .app-top-border {
+    --app-top-border-colour: #{$app-blue-shade-25};
+  }
 }
 
 .app-section-highlight--light-blue {
-  color: govuk-colour('black');
   background-color: $app-light-blue;
 }
 
 .app-section-highlight--light-grey {
-  color: govuk-colour('black');
   background-color: govuk-colour('light-grey');
 }

--- a/src/_stylesheets/_top-border.scss
+++ b/src/_stylesheets/_top-border.scss
@@ -1,0 +1,8 @@
+// Note: The Section Highlight component overrules --app-top-border-colour
+
+.app-top-border {
+  --app-top-border-colour: #{$app-blue-shade-25};
+
+  padding-top: govuk-spacing(2);
+  border-top: 1px solid var(--app-top-border-colour);
+}

--- a/src/_stylesheets/_variables.scss
+++ b/src/_stylesheets/_variables.scss
@@ -1,1 +1,2 @@
 $app-light-blue: govuk-tint($govuk-brand-colour, 95%);
+$app-blue-shade-25: govuk-shade($govuk-brand-colour, 25%);

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -31,6 +31,7 @@
 @import 'mobile-navigation-section';
 @import 'section-highlight';
 @import 'swatch';
+@import 'top-border';
 
 @import 'govuk/utilities';
 @import 'govuk/overrides';
@@ -60,11 +61,6 @@
 
 .app-meta-info {
   color: #484949;
-}
-
-.app-top-border {
-  padding-top: 10px;
-  border-top: 1px solid #16548a;
 }
 
 // Flexbox for arranging things inside the grid
@@ -113,15 +109,3 @@
 .app-grid {
   gap: 15px;
 }
-
-// Other
-.border {
-  padding-top: 10px;
-  border-top: 1px solid #16548a;
-}
-
-.border-white {
-  padding-top: 10px;
-  border-top: 1px solid #ffffff;
-}
-

--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -12,12 +12,12 @@ Accent teal also sits alongside to add impact and help the brand feel more moder
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="border">
+<div class="app-top-border">
 
 {% swatch { label: "Primary blue", hex: "#1D70B8" } %}
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 {% swatch { label: "Accent teal", hex: "#00FFE0" } %}
 
@@ -103,7 +103,7 @@ To maintain consistency across channels the colours within our palette should ne
 ![TODO](./incorrect-colour-combos.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www.w3.org/TR/WCAG22/#contrast-minimum)
 
@@ -113,7 +113,7 @@ Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www
 ![TODO](./incorrect-new-colours.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not create new colours
 
@@ -123,7 +123,7 @@ Do not create new colours
 ![TODO](./incorrect-too-many-colours.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not use too many colours within an application
 
@@ -133,7 +133,7 @@ Do not use too many colours within an application
 ![TODO](./incorrect-gradients.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not mix colours to create gradients (single colour gradients are permitted for use over imagery)
 

--- a/src/logo-system/index.md
+++ b/src/logo-system/index.md
@@ -34,7 +34,7 @@ Our wordmark is our primary identifier and should be used as the lead asset on t
 ![The wordmark for "GOV.UK". The dot is centred vertically and coloured in accent teal.](./logo-elements/wordmark.svg)
 
 </div>
-<div class="border-white">
+<div class="app-top-border">
 
 ### Crown
 
@@ -42,12 +42,12 @@ The crown must always be present but is used as a supporting asset within close 
 
 </div>
 
-<div class="flex-end flex-center border-white">
+<div class="flex-end flex-center app-top-border">
 
 ![The crown element of the GOV.UK logo.](./logo-elements/crown.svg)
 
 </div>
-<div class="border-white">
+<div class="app-top-border">
 
 ### Lock-up
 
@@ -55,7 +55,7 @@ To aid recognition the lock-up combines the crown and wordmark and is used prima
 
 </div>
 
-<div class="flex-end flex-center border-white">
+<div class="flex-end flex-center app-top-border">
 
 ![The lock-up of the crown and GOV.UK wordmark shown together.](./logo-elements/lockup.svg)
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -83,7 +83,7 @@ Wordmark dot = 2× crown dot
 ![Dots from the crown are used to show the correct size of the dot in the wordmark.](./standard-crown.svg)
 
 </div>
-<div class="border-white">
+<div class="app-top-border">
 
 #### Enlarged crown size
 
@@ -91,7 +91,7 @@ Scaling should follow this rule:
 Wordmark dot = 1× crown dot
 
 </div>
-<div class="border-white">
+<div class="app-top-border">
 
 ![Dots from the enlarged crown that's used in the app icon are used to show the correct size of the dot in the wordmark.](./enlarged-crown.svg)
 
@@ -156,7 +156,7 @@ Use the small crown version for anything below the crown’s minimum size, such 
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div class="border">
+<div class="app-top-border">
 
 ### Primary Blue background
 
@@ -168,7 +168,7 @@ When using on a Primary Blue background, the wordmark colour should use White an
 ![](./logo-primary.svg)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 ### Light background
 
@@ -180,7 +180,7 @@ When using against a light background, the wordmark colour should use Black and 
 ![](./logo-light.svg)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 ### Special use
 
@@ -225,7 +225,7 @@ To maintain consistency across channels the logo elements should never be change
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div class="border">
+<div class="app-top-border">
 
 Do not alter colour balance within the wordmark
 
@@ -235,7 +235,7 @@ Do not alter colour balance within the wordmark
 ![](./incorrect-altered-colours.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not distort, stretch or skew the wordmark
 
@@ -245,7 +245,7 @@ Do not distort, stretch or skew the wordmark
 ![](./incorrect-squashed.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not apply drop shadows or effects to the wordmark
 
@@ -255,7 +255,7 @@ Do not apply drop shadows or effects to the wordmark
 ![](./incorrect-effects.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not use the wordmark on overly busy or low-contrast backgrounds
 
@@ -265,7 +265,7 @@ Do not use the wordmark on overly busy or low-contrast backgrounds
 ![](./incorrect-busy.png)
 
 </div>
-<div class="border">
+<div class="app-top-border">
 
 Do not flip, mirror, or rotate the wordmark
 

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -42,7 +42,7 @@ Consistent use of type styles aids clarity and hierarchy. Headings should be att
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="border">
+<div class="app-top-border">
 
 ### Headline styles
 
@@ -55,7 +55,7 @@ Any content over 5 lines should be formatted as a body style
 img goes here
 </div>
 
-<div class="border">
+<div class="app-top-border">
 
 ### Body copy styles
 
@@ -65,7 +65,7 @@ Body copy styles should always be set in Light and should be used for all longer
 <div>
 img goes here
 </div>
-<div class="border">
+<div class="app-top-border">
 
 ### Tags styles
 
@@ -88,7 +88,7 @@ Indicative examples for illustrative purposes only.
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="border">
+<div class="app-top-border">
 
 ### Left aligned text
 
@@ -98,7 +98,7 @@ Where possible we should lead with left-aligned text. It improves readability by
 
 ![TODO](./left-aligned.png)
 
-<div class="border">
+<div class="app-top-border">
 
 ### Centre aligned text
 
@@ -123,7 +123,7 @@ Indicative examples for illustrative purposes only.
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="border">
+<div class="app-top-border">
 
 **Do** use consistent and clear line and letter spacing.
 
@@ -131,7 +131,7 @@ Indicative examples for illustrative purposes only.
 
 ![TODO](./type-settings-do.png)
 
-<div class="border">
+<div class="app-top-border">
 
 **Don't** use line and letter spacing that is too wide or tight.
 


### PR DESCRIPTION
Refactors CSS for the top borders that are applied to some content areas. A semantic name would be nice but I'm not sure there really is one for this.

Closes #100. Builds on top of #124 as it also involves some changes to section highlight styles.

## Changes
- Merged the `.app-top-border`, `.border` and `.border-white` classes together into `.app-top-border`.
- Updated styles to use GOV.UK Frontend spacing and colour functions.
- Updated section highlight styles so that a top-border contained within a brand blue section appears in white automatically. 
- Moved top-border related CSS into its own partial.