### PR TITLE
Fix Markdown headings starting smaller than expected

### DIFF
--- a/eleventy/markdown.js
+++ b/eleventy/markdown.js
@@ -10,7 +10,10 @@ export function setupMarkdownCompilation(eleventyConfig) {
     html: true,
     typographer: true
   })
-    .use(markdownItGovuk)
+    .use(markdownItGovuk, {
+      // Makes h1 -> xl, h2 -> l, h3 -> m, etc.
+      headingsStartWith: 'xl'
+    })
     .use(markdownItAnchor)
 
   /**


### PR DESCRIPTION
We had a mismatch between our heading levels and respective sizes due to a lack of configuration in our use of [markdown-it-govuk](https://www.npmjs.com/package/markdown-it-govuk). This was potentially missed previously due to initially having page titles be part of Markdown content, instead of part of the layout as they are now.

## Changes
- Updates the markdown-it-govuk configuration to start headings at a larger GOV.UK Frontend heading size.

|Element|Previous size|New size|
|:-|:-|:-|
|`h1`|`xl` heading|`xl` heading|
|`h2`|`m` heading|`l` heading|
|`h3`|`s` heading|`m` heading|
|`h4`|unstyled|`s` heading|
|`h5`|unstyled|unstyled|

## Screenshots

|Before|After|
|:-:|:-:|
|<img width="768" height="908" alt="Screenshot of page content with large top heading, a noticably much smaller second level heading, and a third level heading that's the same size as body text" src="https://github.com/user-attachments/assets/31e41eec-f284-4566-8e07-aa763cb9f5eb" />|<img width="768" height="908" alt="Screenshot of page content with large top heading, slightly smaller second level heading, and a third level heading that's slightly larger than body text" src="https://github.com/user-attachments/assets/87242d58-0de5-4db5-b207-27172186f4d1" />|
|<img width="1382" height="908" alt="Screenshot of headings and text alongside videos, with the heading appearing the same size as body text." src="https://github.com/user-attachments/assets/2330e2a5-0fbe-463e-ac6f-7f936818926c" />|<img width="1382" height="908" alt="Screenshot of headings and text alongside videos, with the headings are about 50% larger than the body text." src="https://github.com/user-attachments/assets/205c3c7e-e2ee-4382-b523-153a504c3df5" />|