### PR TITLE
Reduce 'current page' dot size, fix appearance in forced colours

### DIFF
--- a/src/_stylesheets/_aria-current.scss
+++ b/src/_stylesheets/_aria-current.scss
@@ -26,6 +26,12 @@
       transform: translateY(-1px);
       border-radius: 100%;
       background: currentcolor;
+
+      // Force dot colour to match link text in high contrast mode
+      // stylelint-disable-next-line max-nesting-depth
+      @media (forced-colors: active) {
+        background: LinkText;
+      }
     }
   }
 }


### PR DESCRIPTION
What it says on the tin.

Closes #112 and fixes #137.

## Changes
- Reduced size of the 'current page' marker dot in the mobile and sidebar navigation.
- Override the dot colour in forced/high contrast colour modes to use `LinkText` system colour.

## Screenshots
||Before|After|
|:-|:-:|:-:|
|Mobile navigation|<img width="1100" height="902" alt="Mobile navigation with marker dot matching the text x-height." src="https://github.com/user-attachments/assets/a7c39dff-93a6-4dda-babf-03827a5e9470" />|<img width="1100" height="902" alt="Mobile navigation with marker dot matching the logo dot size." src="https://github.com/user-attachments/assets/c62a8d9f-68e8-4f83-aa1a-e52db58a9383" />|
|Sidebar navigation|<img width="494" height="376" alt="Sidebar navigation with marker dot matching the text x-height." src="https://github.com/user-attachments/assets/5f87d8f0-9a00-44f6-9f4e-005265123e14" />|<img width="494" height="376" alt="Mobile navigation with marker dot matching the logo dot size." src="https://github.com/user-attachments/assets/55cd46de-02d0-4313-8974-08cf5468a99d" />|
|Forced colours|<img width="490" height="214" alt="Two yellow links on a black background. The top link is in bold." src="https://github.com/user-attachments/assets/1a37ec54-c686-42fc-ba68-6add4449e3ec" />|<img width="490" height="214" alt="Two yellow links on a black background. The top link is in bold and has a yellow dot offset to the left of it." src="https://github.com/user-attachments/assets/ac7db0d4-f464-444d-b6d4-79212023075b" />|

## Thoughts
They're technically very slightly different. The logo dot comes out at 7.4 pixels in diameter (at least on my fairly high resolution screen). For simplicity's sake, the navigation dot has been changed to 8 pixels, or ½ of the body font size.