### PR TITLE
Fix reference to incorrect variable in video shortcode

### DIFF
--- a/eleventy/shortcodes/video-player.js
+++ b/eleventy/shortcodes/video-player.js
@@ -92,7 +92,7 @@ export const videoPlayer = blockShortcode((options = {}) => {
   // loop = video repeats itself once concluded (useful for short videos)
 
   return `<video${options.classes ? ` class="${options.classes}"` : ''}
-    width="${options.width}"
+    width="${playerWidth}"
     height="${playerHeight}"
     controls
     playsinline


### PR DESCRIPTION
#125 accidentally overwrote a code change made in #109, which I missed when code reviewing it. 🤦 

This restores that change. 