### PR TITLE
Add alt text and refine content in Colour and Typography sections

### DIFF
--- a/src/colour/app/index.md
+++ b/src/colour/app/index.md
@@ -5,9 +5,11 @@ title: App
 
 ## App palette
 
-The app palette contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
+The app palette contains all primary colours, tints, shades and accents.
 
-Our app palette has:
+[Follow the overall colour guidance](/colour/govuk-blue/) to ensure brand coherence across channels.
+
+The app palette has:
 
 - [blues](#blues)
 - [greens](#greens)
@@ -65,24 +67,26 @@ Indicative examples for illustrative purposes only.
 
 ### Mobile web header
 
-![TODO](./mobile-header.png)
+![Screenshot of the GOV.UK website on mobile, showing the Primary blue header, with the lock-up of the wordmark and crown in white. The dot is in Accent teal. Page content is greyed out.](./mobile-header.png)
 
 ### App header
-
-![TODO](./app-header1.png) ![TODO](./app-header2.png) ![TODO](./app-header3.png) ![TODO](./app-header4.png)
-
-Indicative examples for illustrative purposes only.
-
-## Examples
 
 {% callout %}
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-Within app we lead with the Primary Blue and Accent Teal, from splash screen to core components.
+![Screenshot of the GOV.UK app, showing the start page of topics as greyed out.](./app-header1.png) ![Screenshot of the GOV.UK app, showing the Benefits topic page.](./app-header2.png) ![Screenshot of the GOV.UK app, showing the 'Pages you've visited' page.](./app-header3.png) ![Screenshot of the GOV.UK app, showing the Settings page.](./app-header4.png)
+
+## Examples
+
+Within app we lead with the Primary blue and Accent teal, from splash screen to core components.
 
 Where appropriate we can introduce harmonious colours to aid with structure and hierarchy of content – such as tints within cards or contextual colours that enhances navigation.
 
 Colour should be applied in a way that does not add visual complexity or reduce accessibility.
 
-![TODO](./app-homepage.png) ![TODO](./app-settings.png)
+{% callout %}
+Indicative examples for illustrative purposes only.
+{% endcallout %}
+
+![Screenshot of the GOV.UK app, showing the start page of topics, including tinted tile buttons.](./app-homepage.png) ![Screenshot of the GOV.UK app, showing the Settings page, including tinted menus.](./app-settings.png)

--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -3,7 +3,7 @@ order: 0
 title: GOV.UK is a blue brand
 ---
 
-Our core brand colours are Primary Blue and Accent Teal.
+Our core brand colours are Primary blue and Accent teal.
 
 We’re building on the primary blue already in place to support recognition and trust. Using it more consistently will make it a clear visual signature of GOV.UK.
 
@@ -26,14 +26,14 @@ Accent teal also sits alongside to add impact and help the brand feel more moder
 </div>
 <div>
 
-![TODO](./wordmark-on-blue.svg)
+![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark-on-blue.svg)
 
 </div>
 {% endgrid %}
 
 ## Coherency across channels
 
-We lead with the Primary Blue and Accent Teal across all GOV.UK channels. From the blue header on web and app, to branded banners within social platforms, this aids brand recognition and establishes trust.
+We lead with the Primary blue and Accent teal across all GOV.UK channels. From the blue header on web and app, to branded banners within social platforms, this aids brand recognition and establishes trust.
 
 {% callout %}
 Indicative examples for illustrative purposes only.
@@ -48,7 +48,7 @@ Indicative examples for illustrative purposes only.
 
 <div class="app-section-highlight__wrapper--space-around">
 
-![TODO](./mobile-web-header.png)
+![Screenshot of GOV.UK website on mobile, showing the Primary blue header, with the lock-up of the wordmark and crown in white. The dot is in Accent teal.](./mobile-web-header.png)
 
 </div>
 </div>
@@ -67,7 +67,7 @@ Indicative examples for illustrative purposes only.
 
 <div class="app-section-highlight__wrapper--space-around">
 
-![TODO](./app-header.png)
+![Screenshot of GOV.UK app, showing the Primary blue app header with the wordmark in white and the dot in Accent teal.](./app-header.png)
 
 </div>
 </div>
@@ -78,7 +78,7 @@ Indicative examples for illustrative purposes only.
 
 <div class="app-section-highlight__wrapper--space-around">
 
-![TODO](./youtube-profile.png)
+![Screenshot of YouTube profile on mobile, showing blue and teal used in the banner image.](./youtube-profile.png)
 
 </div>
 </div>
@@ -90,7 +90,7 @@ Indicative examples for illustrative purposes only.
 
 You must make sure that the contrast ratio of colours used meets [Web Content Accessibility Guidelines (WCAG 2.2) success criterion 1.4.3 Contrast (minimum) level AA](https://www.w3.org/TR/WCAG22/#contrast-minimum).
 
-![TODO](./colour-contrast.png)
+![A very large grid of colour combinations. Tiny red tags show where combinations do not meet minimum colour contrast requirements.](./colour-contrast.png)
 
 ## Incorrect colour usage
 
@@ -100,7 +100,7 @@ To maintain consistency across channels the colours within our palette should ne
 
 <div>
 
-![TODO](./incorrect-colour-combos.png)
+![](./incorrect-colour-combos.png)
 
 </div>
 <div class="app-top-border">
@@ -110,7 +110,7 @@ Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www
 </div>
 <div>
 
-![TODO](./incorrect-new-colours.png)
+![](./incorrect-new-colours.png)
 
 </div>
 <div class="app-top-border">
@@ -120,7 +120,7 @@ Do not create new colours
 </div>
 <div>
 
-![TODO](./incorrect-too-many-colours.png)
+![](./incorrect-too-many-colours.png)
 
 </div>
 <div class="app-top-border">
@@ -130,7 +130,7 @@ Do not use too many colours within an application
 </div>
 <div>
 
-![TODO](./incorrect-gradients.png)
+![](./incorrect-gradients.png)
 
 </div>
 <div class="app-top-border">

--- a/src/colour/index.md
+++ b/src/colour/index.md
@@ -6,7 +6,7 @@ hero: ./colour-hero.svg
 
 <div class="hero">
 
-![TODO](./colour-hero.svg)
+![](./colour-hero.svg)
 
 </div>
 
@@ -18,21 +18,30 @@ Always use the GOV.UK colour palette alongside other accessibility principles. T
 
 ## Palette overview
 
-Our palette consists of 4 tiers;
-Primary, Tints, Shades and Accents.
+Our palette consists of 4 tiers: primary, tints, shades and accents.
 
 ### Primary
 
-Primary colours form the foundation of the brand palette, with blue as the core colour that anchors the visual identity. The additional primary colours are complementary and can be used to express tone, emphasis, or differentiation while maintaining brand cohesion. These colours should be applied thoughtfully to reinforce consistency and clarity across all communications.
+Primary colours form the foundation of the brand palette, with blue as the core colour that anchors the visual identity.
+
+The additional primary colours are complementary and can be used to express tone, emphasis, or differentiation while maintaining brand cohesion.
+
+These colours should be applied thoughtfully to reinforce consistency and clarity across all communications.
 
 ### Tints
 
-Tints are lighter variations of the primary colours, created by adding white. These are useful for backgrounds, highlights, and creating a sense of space while maintaining brand coherence.
+Tints are lighter variations of the primary colours, created by adding white.
+
+These are useful for backgrounds, highlights, and creating a sense of space while maintaining brand coherence.
 
 ### Shades
 
-Shades are darker variations of the primary colours, created by adding black. They provide depth, contrast, and are ideal for text or design elements requiring emphasis.
+Shades are darker variations of the primary colours, created by adding black.
+
+They provide depth, contrast, and are ideal for text or design elements requiring emphasis.
 
 ### Accents
 
-Accents are supplementary colours used sparingly to highlight important content, inject energy, or signal specific actions or statuses within a design. They should complement the primary palette without overwhelming it.
+Accents are supplementary colours used sparingly to highlight important content, inject energy, or signal specific actions or statuses within a design.
+
+They should complement the primary palette without overwhelming it.

--- a/src/colour/print/index.md
+++ b/src/colour/print/index.md
@@ -7,7 +7,7 @@ title: Print
 
 Use these colours for printed materials like documents, or in custom formats where appropriate.
 
-Our print palette has:
+The print palette has:
 
 - [blues](#blues)
 - [greens](#greens)

--- a/src/colour/social/index.md
+++ b/src/colour/social/index.md
@@ -5,9 +5,11 @@ title: Social
 
 ## Social palette
 
-The social palette requires moments of increased brand expression and flex and therefore contains all primary colours, tints, shades and accents. Guidance outlined within the overview section should be followed to ensure brand coherence across channels.
+The social palette requires moments of increased brand expression and flex and therefore contains all primary colours, tints, shades and accents.
 
-Our social palette has:
+[Follow the overall colour guidance](/colour/govuk-blue/) to ensure brand coherence across channels.
+
+The social palette has:
 
 - [blues](#blues)
 - [greens](#greens)
@@ -57,9 +59,11 @@ Our social palette has:
 
 ## Use colour to reflect tone
 
-Our updated palette has been developed to allow a range in expression across the inform to inspire scale. There are moments where the brand needs to feel functional and serious, guiding users seamlessly to the content and services they need. With the introduction of new channels such as social, there are also moments where the brand needs impact and visual differentiation.
+Our updated palette has been developed to allow a range in expression across the inform to inspire scale. 
 
-Within our palette there are two approaches to colour application; tonal colours and companion colours.
+There are moments where the brand needs to feel functional and serious, guiding users seamlessly to the content and services they need. With the introduction of new channels such as social, there are also moments where the brand needs impact and visual differentiation.
+
+Within our palette there are two approaches to colour application: tonal colours and companion colours.
 
 Depending on tonal requirement, each can be used to achieve a different level of expression. The following guidance details the use of these two approaches.
 
@@ -67,43 +71,43 @@ Depending on tonal requirement, each can be used to achieve a different level of
 
 ### Inform <--------> Inspire
 
-![TODO](./tone-black-and-white.png)
+![Text "National mourning guidance" in black, within a white circle, on a black background.](./tone-black-and-white.png)
 B&W
 
-![TODO](./tone-dark-shade.png)
+![Text "Get support with the cost of living" in blue shade 50%, within a white circle, on a blue shade 50% background.](./tone-dark-shade.png)
 Dark shade
 
-![TODO](./tone-primary-blue.png)
+![Text "Fuel duty will be frozen next year" in Primary blue, within a white circle, on a Primary blue background.](./tone-primary-blue.png)
 Primary blue
 
-![TODO](./tone-tonal-colour.png)
+![Text "Get help with your pension" in a dark blue, within a Accent blue circle, on a Primary blue background.](./tone-tonal-colour.png)
 Tonal colour
 
-![TODO](./tone-companion-colour.png)
+![Text "Learning to drive a car" in Accent green, within a blue shade 50% background, on an Accent green background.](./tone-companion-colour.png)
 Companion colour
 
 ### Tonal colour examples
-
-{% callout %}
-Indicative examples for illustrative purposes only.
-{% endcallout %}
 
 Colour can be used to reflect tone of a message.
 
 For more sensitive messaging, colours from within the same tonal range are used to feel more serious, informative and functional.
 
-![TODO](./example-tonal-1.png)
+{% callout %}
+Indicative examples for illustrative purposes only.
+{% endcallout %}
+
+![Text "Fuel duty will be frozen next year" in Green shade 50%, within a whte circle, on a Green tint 50% background.](./example-tonal-1.png)
 
 {% swatch { label: "Green tint 95%", hex: "#F3F9F7" } %}
 {% swatch { label: "Green shade 50%", hex: "#09442D" } %}
 
-![TODO](./example-tonal-2.png)
+![Text "Strong winds and expected disruptions" in white, above the text is an exclamation mark icon in Red shade 50% inside a small circle in Accent red, on a Primary red background.](./example-tonal-2.png)
 
 {% swatch { label: "Primary red", hex: "#CA3535" } %}
 {% swatch { label: "Red shade 50%", hex: "#651B1B" } %}
 {% swatch { label: "Accent red", hex: "#FF5E5E" } %}
 
-![TODO](./example-tonal-3.png)
+![Text "Get your council bill reduced as a student" in white, with a Primary purple lozenge highlighting the word "reduced". Below the text is a large Accent purple arrow. Image background is in Purple shade 50%.](./example-tonal-3.png)
 
 {% swatch { label: "Purple tint 95%", hex: "#F6F5FA" } %}
 {% swatch { label: "Primary purple", hex: "#54319F" } %}
@@ -112,11 +116,13 @@ For more sensitive messaging, colours from within the same tonal range are used 
 
 ## Companion colours
 
-Use companion colours when you need to emphasise something, like prompting action or sharing something positive. We’ve kept the set to nine combinations to make sure they stay accessible.
+Use companion colours when you need to emphasise something, like prompting action or sharing something positive. We’ve kept the set to 9 combinations to make sure they stay accessible.
 
-Some pairings may be harder to see for people with visual impairments or colour blindness. Choose combinations carefully and use a tool like [WhoCanUse.com](https://www.whocanuse.com/) to check they meet [WCAG 2.2 Contrast (Minimum) Level AA](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).
+Some pairings may be harder to see for people with visual impairments or colour blindness. 
 
-Don’t rely on colour alone to show meaning, signal an action or prompt a response. For more detail, see [WCAG 2.2: Use of Colour (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
+Choose combinations carefully and use a tool like [WhoCanUse.com](https://www.whocanuse.com/) to check they meet [WCAG 2.2 Contrast (Minimum) Level AA](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html).
+
+Do not rely on colour alone to show meaning, signal an action or prompt a response. For more detail, see [WCAG 2.2: Use of Colour (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
 
 Remember, some users browse with high-contrast settings or dark mode. Colours may need to be adjusted to work in those contexts.
 
@@ -175,18 +181,18 @@ For more sensitive messaging, colours from within the same tonal range are used 
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-![TODO](./example-companion-1.png)
+![Text "Get your council bill reduced as a student" in white, with "reduced" in black text within a Primary yellow lozenge highlight. Above is a large Primary yellow arrow. Image background is in Primary blue.](./example-companion-1.png)
 
 {% swatch { label: "Primary blue", hex: "#1D70B8" } %}
 {% swatch { label: "Primary yellow", hex: "#FFDD00" } %}
 
-![TODO](./example-companion-2.png)
+![Text "See to see if you need an Electronic Travel Authorisation (ETA)" in Blue shade 50%. Above is a map pin graphic in Primary magenta. Image background is in Magenta tint 90%.](./example-companion-2.png)
 
 {% swatch { label: "Primary magenta", hex: "#CA357C" } %}
 {% swatch { label: "Blue shade 50%", hex: "#0F385C" } %}
 {% swatch { label: "Magenta tint 95%", hex: "#FCF5F8" } %}
 
-![TODO](./example-companion-3.png)
+![Text "Driving abroad" in white, with topic text "Step by step" above in Accent green, within a Blue shade 50% circle. Image background is Accent green.](./example-companion-3.png)
 
 {% swatch { label: "Accent green", hex: "#66F39E" } %}
 {% swatch { label: "Blue shade 50%", hex: "#0F385C" } %}

--- a/src/colour/web/index.md
+++ b/src/colour/web/index.md
@@ -11,7 +11,7 @@ To reference colours from the palette directly you should use the `govuk-colour`
 
 Avoid using the palette colours if there is a Sass variable that is designed for your context. For example, if you are styling the error state of a component you should use the `$govuk-error-colour` Sass variable rather than `govuk-colour("red")`.
 
-Our web palette has:
+The web palette has:
 
 - [blues](#blues)
 - [greens](#greens)
@@ -102,13 +102,13 @@ Only use this colour to indicate which element is focused on. For example, when 
 
 {% swatch { label: "$govuk-error-colour", hex: "#CA3535" } %}
 
-Use for error messages
+Use for error messages.
 
-#### Success state
+#### Success state.
 
 {% swatch { label: "$govuk-success-colour", hex: "#11875A" } %}
 
-Use for success messages
+Use for success messages.
 
 #### Brand colour
 
@@ -120,4 +120,4 @@ Use for success messages
 Indicative examples for illustrative purposes only.
 {% endcallout %}
 
-![TODO](./example.png)
+![A screenshot of the GOV.UK homepage on desktop, showing web palette colours such as Primary blue for the header and links and Primary purple for visited links.](./example.png)

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -206,7 +206,7 @@ Get help with...
 Step-by-step guides
 {% endfigure %}
 
-{% figure { src: "./video-thumb-influencer.png", alt: "A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a background, which is a purple circular title graphic.", classes: "govuk-!-text-align-left" } %}
+{% figure { src: "./video-thumb-influencer.png", alt: "A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a purple background, with the title in a dark purple circle.", classes: "govuk-!-text-align-left" } %}
 Influencer/presenter
 {% endfigure %}
 
@@ -260,32 +260,32 @@ Indicative examples for illustrative purposes only.
 
 <div>
 
-![TODO](./storyboard-1.png)
+![Series of images showing the storyboard for an Instagram story that guides the user through a DBS (Disclosure and Barring Service) check. Light blue circular and lozenge shapes are used to create icons and highlights to emphasise key information.](./storyboard-1.png)
 
 </div> 
 <div>
 
-![TODO](./storyboard-2.png)
+![](./storyboard-2.png)
 
 </div>
 <div>
 
-![TODO](./storyboard-3.png)
+![](./storyboard-3.png)
 
 </div>
 <div>
 
-![TODO](./storyboard-4.png)
+![](./storyboard-4.png)
 
 </div>
 <div>
 
-![TODO](./storyboard-5.png)
+![](./storyboard-5.png)
 
 </div>
 <div>
 
-![TODO](./storyboard-6.png)
+![](./storyboard-6.png)
 
 </div>
 {% endgrid %}
@@ -304,7 +304,7 @@ To keep things consistent, avoid the following:
 
 Dot not overuse the dot
 
-![Crossed out title graphic with an blank dot on the top left. The title is placed in the centre within a large circle, and also contains a lozenge-shaped text highlight.](./incorrect-overuse.png)
+![Crossed out graphic with a small blank dot on the top left. Text placed in the centre within a large circle, and also contains a lozenge-shaped text highlight.](./incorrect-overuse.png)
 
 </div>
 <div>
@@ -313,7 +313,7 @@ Dot not overuse the dot
 
 Dot not use the dot in a decorative way
 
-![Crossed out title graphic with a dot placed off-centre in the background.](./incorrect-decorative.png)
+![Crossed out graphic some text, with a dot placed off-centre in the background.](./incorrect-decorative.png)
 
 </div>
 <div>
@@ -322,7 +322,7 @@ Dot not use the dot in a decorative way
 
 Do not distort or skew the dot
 
-![Crossed out title graphic with the title placed inside an oval.](./incorrect-distorted.png)
+![Crossed out graphic with some text placed inside a stretched-out oval.](./incorrect-distorted.png)
 
 </div>
 <div>

--- a/src/graphic-device/expression/index.md
+++ b/src/graphic-device/expression/index.md
@@ -19,14 +19,14 @@ Indicative examples for illustrative purposes only.
 
 ### Guides
 
-![A chart showing some statistics presented within circles.](./expression-guides.png)
+![Text "How to register to vote", above is smaller text for the topic "Step by step guide", all within a dark blue circle on a yellow background.](./expression-guides.png)
 
 </div>
 <div>
 
 ### Highlights
 
-![A title graphic for 'Get support with the cost of living'. "Support" is in a lozenge-shaped highlight.](./expression-highlights.png)
+![Text 'Get support with the cost of living' with "support" in a lozenge-shaped highlight.](./expression-highlights.png)
 
 </div>
 <div>
@@ -40,7 +40,7 @@ Indicative examples for illustrative purposes only.
 
 ### Informs
 
-![A title graphic for a 'Step by step guide' called 'How to register to vote'](./expression-informs.png)
+![Infographic showing statistics for the 3 most visited pages on the GOV.UK website.](./expression-informs.png)
 
 </div>
 {% endgrid %}

--- a/src/graphic-device/index.md
+++ b/src/graphic-device/index.md
@@ -4,7 +4,7 @@ title: Graphic device
 hero: ./hero.svg
 ---
 
-## The Dot
+## The dot
 
 Our dot is the bridge between government and the UK, by the side of users to help make information and services easier and more useful.
 
@@ -12,7 +12,7 @@ Used within our wordmark and as a graphic device across all GOV.UK channels, the
 
 {% sectionHighlight %}
 
-![The GOV.UK wordmark, with an arrow that points to the dot.](./the-dot.svg)
+![The GOV.UK wordmark. An arrow points to the vertically-centred dot between 'GOV' and 'UK'.](./the-dot.svg)
 
 {% endsectionHighlight %}
 

--- a/src/index.md
+++ b/src/index.md
@@ -28,4 +28,4 @@ This flexibility comes from how we use key brand elements – the wider colour p
 
 These guidelines show how to apply the brand in different contexts to meet the needs of people using GOV.UK every day.
 
-![TODO](./inform-inspire.svg)
+![](./inform-inspire.svg)

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -14,7 +14,7 @@ An example of this is the GOV.UK app icon.
 
 {% figure {
   src: "./wordmark-on-blue.svg",
-  alt: "GOV.UK wordmark shown on blue background.",
+  alt: "Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.",
   classes: "govuk-!-margin-bottom-0",
   captionPosition: "top"
 } %}
@@ -25,7 +25,7 @@ An example of this is the GOV.UK app icon.
 
 {% figure {
   src: "./crown-on-blue.svg",
-  alt: "Crown shown on blue background.",
+  alt: "Crown shown as white on a Primary blue background.",
   classes: "govuk-!-margin-bottom-0",
   captionPosition: "top"
 } %}
@@ -36,7 +36,7 @@ An example of this is the GOV.UK app icon.
 
 {% figure {
   src: "./app-icon-on-blue.svg",
-  alt: "[Wordmark and crown on blue background, with a border outline to show positioning of these logo elements as an app icon.",
+  alt: "App icon with a Primary blue background, showing a stacked lock-up of the GOV.UK wordmark and crown. A rounded square outline shows positioning of logo elements.",
   classes: "govuk-!-margin-bottom-0",
   captionPosition: "top"
 } %}

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -30,7 +30,7 @@ In both horizontal and stacked lock-ups, the space between the wordmark and prod
 
 <div class="app-grid__cell--vertical-align-end">
 
-![Various diagrams of the GOV.UK Pay lock-up, showing how the dot is used to set spacing between the product name and wordmark. Horizontal and stacked lock-ups are shown.](./lockup-1.svg)
+![Various diagrams of the GOV.UK Pay lock-up in black showing how the dot is used to set spacing between the product name and wordmark. Horizontal and stacked lock-ups are shown. The dot between 'GOV' and 'UK' is Primary blue.](./lockup-1.svg)
 
 </div>
 <div class="app-grid__cell--vertical-align-end">

--- a/src/logo-system/index.md
+++ b/src/logo-system/index.md
@@ -6,7 +6,7 @@ hero: ./hero.svg
 
 <div class="hero">
 
-![TODO](./hero.svg)
+![](./hero.svg)
 
 </div>
 
@@ -31,7 +31,7 @@ Our wordmark is our primary identifier and should be used as the lead asset on t
 
 <div class="app-grid__cell--vertical-align-end">
 
-![The wordmark for "GOV.UK". The dot is centred vertically and coloured in accent teal.](./logo-elements/wordmark.svg)
+![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./logo-elements/wordmark.svg)
 
 </div>
 <div class="app-top-border">

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -15,7 +15,7 @@ As our primary identifier, the GOV.UK wordmark should be used in all application
 
 <div class="app-section-highlight__wrapper--logo">
 
-![The wordmark for "GOV.UK". The dot is centred vertically and coloured in accent teal.](./wordmark.svg)
+![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark.svg)
 
 </div>
 {% endsectionHighlight %}
@@ -30,7 +30,7 @@ As our primary identifier, the GOV.UK wordmark should be used in all application
 
 <div class="app-section-highlight__wrapper--logo">
 
-![The crown element of the GOV.UK logo.](./crown2.svg)
+![The crown element of the GOV.UK logo, shown as white on a Primary blue background.](./crown2.svg)
 
 </div>
 {% endsectionHighlight %}
@@ -41,7 +41,7 @@ A lock-up system where we can position the crown in close proximity to the GOV.U
 
 <div>
 
-![Desktop and mobile background showing the GOV.UK wordmark placed at the very centre with the crown centred at the bottom.](./crown-supporting-element.svg)
+![Desktop and mobile backgrounds showing the GOV.UK wordmark centred on a Primary blue background with the crown centred on the bottom margin.](./crown-supporting-element.svg)
 
 </div>
 

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -18,7 +18,7 @@ An example of this is in profile icons.
 
 <!-- TODO: duplicated file also in ../app -->
 
-![GOV.UK wordmark shown on blue background.](./wordmark-on-blue.svg)
+![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark-on-blue.svg)
 
 </div>
 
@@ -28,7 +28,7 @@ An example of this is in profile icons.
 
 <!-- TODO: duplicated file also in ../app -->
 
-![Crown shown on blue background.](./crown-on-blue.svg)
+![The crown element of the GOV.UK logo, shown as white on a Primary blue background.](./crown-on-blue.svg)
 
 </div>
 
@@ -36,7 +36,7 @@ An example of this is in profile icons.
 
 ### Profile icons
 
-![App icon showing a stacked lock-up of the GOV.UK wordmark and crown. A circle outline shows positioning of logo elements.](./profile-icon-on-blue.svg)
+![Social profile icon with a Primary blue background, showing a stacked lock-up of the GOV.UK wordmark and crown. A circle outline shows positioning of logo elements.](./profile-icon-on-blue.svg)
 
 </div>
 {% endgrid %}

--- a/src/typography/app/index.md
+++ b/src/typography/app/index.md
@@ -15,12 +15,14 @@ Whilst there may be cases where it is not possible, we should always try to use 
 
 <!-- TODO: image is duplicated in ../social/ -->
 
-![TODO](./gds-transport.svg)
+![Sample of GDS Transport font.](./gds-transport.svg)
 {% endsectionHighlight %}
 
 ## OS native fonts
 
-It may not always be possible to use GDS Transport, such as within native operating system environments. In such cases, it is recommended to use the platform’s default system typeface to ensure consistency, performance, and accessibility.
+It may not always be possible to use GDS Transport, such as within native operating system environments.
+
+In such cases, it is recommended to use the platform’s default system typeface to ensure consistency, performance, and accessibility.
 
 {% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
@@ -28,5 +30,5 @@ For example, on Apple (iOS, macOS) use SF Pro, the system font designed for opti
 
 Using the system typeface ensures better performance, scalability, and adherence to platform conventions, resulting in a more polished and user-friendly app, it does however affect brand recognition and consistency.
 
-![TODO](./sf-pro.svg)
+![Sample of SF Pro font.](./sf-pro.svg)
 {% endsectionHighlight %}

--- a/src/typography/index.md
+++ b/src/typography/index.md
@@ -6,13 +6,13 @@ hero: ./type-hero.svg
 
 <div class="hero">
 
-![TODO](./type-hero.svg)
+![](./type-hero.svg)
 
 </div>
 
 Typography is a core element to our identity, shaping how our brand is perceived across all GOV.UK channels.
 
-This section outlines the correct application of typography throughout our channels. Providing guidance on weight, scale, hierarchy and alternatives for when our primary typeface isn’t available.
+This section outlines the correct application of typography throughout our channels. Providing guidance on weight, scale, hierarchy and alternatives for when our primary typeface is not available.
 
 ## GDS Transport
 
@@ -25,15 +25,17 @@ The Government Digital Service adapted it in 2012 for digital use, bringing the 
 
 Using GDS Transport makes GOV.UK easier to recognise and information easier to read on any device.
 
-![TODO](./transport-font.svg)
+<div class="scale width-80 right edge">
+
+![Sample of GDS Transport typeface in bold and light weight](./transport-font.svg)
 
 {% endsectionHighlight %}
 
 ### Weights
 
-GDS transport consists of two weights; **Light** and **Bold**.
+GDS Transport consists of two weights: light and bold.
 
-![TODO](./bold-light.svg)
+![Another sample of GDS Transport typeface in bold and light weight](./bold-light.svg)
 
 ### Glyphs
 
@@ -43,9 +45,9 @@ GDS Transport offers a wide range of glyph support. It includes a comprehensive 
 
 GDS Transport Light
 
-![TODO](./font-specimen-light.svg)
+![GDS Transport character set in light weight.](./font-specimen-light.svg)
 
 GDS Transport Bold
 
-![TODO](./font-specimen-bold.svg)
+![GDS Transport character set in bold weight.](./font-specimen-bold.svg)
 {% endsectionHighlight %}

--- a/src/typography/print/index.md
+++ b/src/typography/print/index.md
@@ -5,8 +5,13 @@ title: Print
 
 ## Document element sizes
 
-The recommended sizes for common document formats are illustrated here.
+The recommended minimum sizes for typography in common document formats are:
+
+- logo: 10mm height
+- header text: 16pt
+- body text: 12pt
+
 {% sectionHighlight { classes: "app-section-highlight--dark-magenta" } %}
 
-![TODO](./print-guides.svg)
+![Diagram of A4-sized letterhead and letter. Labels show the minimum sizes for the logo, header text and body text.](./print-guides.svg)
 {% endsectionHighlight %}

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -15,7 +15,7 @@ Whilst there may be cases where it is not possible, we should always try to use 
 
 <!-- TODO: image is duplicated in ../app/ -->
 
-![TODO](./gds-transport.svg)
+![Sample of GDS Transport font.](./gds-transport.svg)
 {% endsectionHighlight %}
 
 ## Building visual hierarchy
@@ -30,13 +30,15 @@ Indicative examples for illustrative purposes only.
 
 {% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
-![TODO](./type-hierarchy.png)
+![Graphic promoting pension information, with labels pointing out different type styles for the tag, headline and body copy, each with different font sizes and weights.](./type-hierarchy.png)
 
 {% endsectionHighlight %}
 
 ## Styles
 
-Consistent use of type styles aids clarity and hierarchy. Headings should be attention-grabbing, whilst body text should prioritize readability with appropriate line spacing and contrast.
+Consistent use of type styles aids clarity and hierarchy.
+
+Headings should be attention-grabbing, whilst body text should prioritize readability with appropriate line spacing and contrast.
 
 <!-- TODO: lots to do here, some of the below should probably be in images -->
 
@@ -92,21 +94,27 @@ Indicative examples for illustrative purposes only.
 
 ### Left aligned text
 
-Where possible we should lead with left-aligned text. It improves readability by keeping spacing consistent and reducing eye strain. It prevents uneven gaps (rivers of white space) found in fully justified text, making it easier to follow, especially for users with dyslexia or visual impairments.
+Where possible we should lead with left-aligned text.
+
+It improves readability by keeping spacing consistent and reducing eye strain.
+
+It prevents uneven gaps (rivers of white space) found in fully justified text, making it easier to follow, especially for users with dyslexia or visual impairments.
 
 </div>
 
-![TODO](./left-aligned.png)
+![](./left-aligned.png)
 
 <div class="app-top-border">
 
 ### Centre aligned text
 
-Centred text should be used sparingly for shorter headlines, predominantly within social channels. Whilst it grabs attention, it reduces readability in longer text, making it harder for the eye to track.
+Centred text should be used sparingly for shorter headlines, predominantly within social channels.
+
+Whilst it grabs attention, it reduces readability in longer text, making it harder for the eye to track.
 
 </div>
 
-![TODO](./centre-aligned.png)
+![](./centre-aligned.png)
 {% endgrid %}
 
 ## Type settings
@@ -129,7 +137,7 @@ Indicative examples for illustrative purposes only.
 
 </div>
 
-![TODO](./type-settings-do.png)
+![](./type-settings-do.png)
 
 <div class="app-top-border">
 
@@ -138,7 +146,7 @@ Indicative examples for illustrative purposes only.
 </div>
 <div>
 
-![TODO](./type-settings-dont-1.png) ![TODO](./type-settings-dont-2.png)</div>
+![](./type-settings-dont-1.png) ![](./type-settings-dont-2.png)</div>
 
 {% endgrid %}
 
@@ -150,9 +158,11 @@ Where standard system fonts are available, Helvetica Neue or Arial should be use
 
 {% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
-In cases where system fonts are unavailable, the closest replacement should be used. This should always be a sans serif, low contrast typeface with a focus on accessibility.
+In cases where system fonts are unavailable, the closest replacement should be used.
 
-![TODO](./helvetica-neue.svg)
-![TODO](./arial.svg)
+This should always be a sans serif, low contrast typeface with a focus on accessibility.
+
+![Sample of Helvetica Neue font.](./helvetica-neue.svg)
+![Sample of Arial font.](./arial.svg)
 
 {% endsectionHighlight %}

--- a/src/typography/web/index.md
+++ b/src/typography/web/index.md
@@ -9,8 +9,8 @@ If your service is on the service.gov.uk subdomain you must use the GDS Transpor
 
 {% sectionHighlight { classes: "app-section-highlight--light-blue" } %}
 
-For in depth guidance on how to correctly apply typography within the web channel, refer to the [Design System Guidelines](https://design-system.service.gov.uk/styles/typeface/).
+For in depth guidance on how to correctly apply typography within the web channel, refer to the guidelines on the [GOV.UK Design System](https://design-system.service.gov.uk/styles/typeface/).
 
-![TODO](./design-system.png)
+![Screenshot of the Typeface page on the GOV.UK Design System.](./design-system.png)
 
 {% endsectionHighlight %}


### PR DESCRIPTION
Adds [alt text drafted in Google doc](https://docs.google.com/spreadsheets/d/1-5yx308EBMI0Zndzdm3uVpUlvIrnauTH3bN_W5UbL8g/edit?usp=sharing) and makes minor fixes to refine content in the Colour and Typography sections.