### PR TITLE
Moves breadcrumbs to above page title

### DIFF
--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -55,16 +55,6 @@
       text: "This is a new service. Help us improve it by giving your feedback."
     }) }}
   {%- endif %}
-  {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
-  {# Some pages, like test pages, don't have ancestors #}
-  {% if ancestors.length %}
-    {{
-      govukBreadcrumbs({
-        items: ancestors | asBreadcrumbItems
-      })
-    }}
-  {% endif %}
 
   <div class="govuk-grid-row govuk-main-wrapper">
     <nav class="govuk-grid-column-one-third app-chapter-navigation" aria-label="Pages in this section">
@@ -74,13 +64,27 @@
         renderedPageUrl: page.url
       })}}
     </nav>
-  {#
-    To avoid re-producing GOV.UK Frontend's markup for the `main` block
-    the grid-row will be closed at the end of the `main` block
-  #}
+
+    <div class="govuk-grid-column-two-thirds">
+      {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+      {# Some pages, like test pages, don't have ancestors #}
+      {% if ancestors.length %}
+        {{
+          govukBreadcrumbs({
+            classes: 'app-breadcrumbs',
+            items: ancestors | asBreadcrumbItems
+          })
+        }}
+      {% endif %}
+
+      {#
+        To avoid re-producing GOV.UK Frontend's markup for the `main` block
+        the grid row and column will be closed at the end of the `main` block
+      #}
 {% endblock %}
 
-{% set mainClasses = 'govuk-grid-column-two-thirds app-main-wrapper app-prose' %}
+{% set mainClasses = 'app-main-wrapper app-prose' %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{title}}</h1>
@@ -101,7 +105,8 @@
 {% endblock %}
 
 {% block main %}
-  {{super()}}
+    {{super()}}
+    </div>
   </div>
 {% endblock %}
 

--- a/src/_stylesheets/_breadcrumbs.scss
+++ b/src/_stylesheets/_breadcrumbs.scss
@@ -1,0 +1,4 @@
+.app-breadcrumbs {
+  margin-top: 0;
+  margin-bottom: govuk-spacing(1);
+}

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -23,6 +23,7 @@
 
 // App components
 @import 'aria-current';
+@import 'breadcrumbs';
 @import 'callout';
 @import 'grid';
 @import 'inform-inspire';


### PR DESCRIPTION
Closes #139.

## Changes
- Moved breadcrumb component to be above the page title.
- Rejigged some of the wrapping containers so that the breadcrumbs appear outside of the `<main>` element.
- Added styles to reduce the margins on the breadcrumbs, so that they align with the side navigation on pages that have both. (This mirrors the spacing we use on the Design System website.) 

## Screenshots
|Before|After|
|:-:|:-:|
|<img width="2048" height="924" alt="Screenshot of the graphic device expression page with breadcrumbs located below the phase banner and a significant space above the side navigation and content columns." src="https://github.com/user-attachments/assets/1a860af6-257d-4091-9700-35abe53ad1c0" />|<img width="2048" height="924" alt="Screenshot of the same page with breadcrumbs located in the content column and directly before the heading, with the side navigation next to it." src="https://github.com/user-attachments/assets/e80d2038-a108-43b8-851a-81a860778b46" />|