### PR TITLE
Move padding on logo wrapper img to element

### DIFF
--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -45,11 +45,11 @@
 }
 
 .app-section-highlight__wrapper--logo {
+  padding: govuk-spacing(6);
   text-align: center;
 
   img {
     max-width: 60%;
-    padding: govuk-spacing(6);
   }
 }
 


### PR DESCRIPTION
Moves the padding from the 'img' element within `app-sectiion-highlight__warpper--logo` to that element itself.

This came up in [this comment thread](github.com/alphagov/govuk-brand-guidelines/pull/132#pullrequestreview-3174209878). I missed this when copying and pasting styles 🙈

Whilst it's unlikely that this will cause problems in most browsers and [MDN itself says that images are allowed to have margin/padding](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#styling_with_css), it feels tidier to have the spacing be handled by the surrounding element.