### PR TITLE
Add `insideHTML` option to `blockShortcode`

### DIFF
--- a/eleventy/shortcodes/utils.js
+++ b/eleventy/shortcodes/utils.js
@@ -9,10 +9,10 @@ import { outdent } from 'outdent'
  */
 
 export function blockShortcode(shortcode) {
-  return function ({ indent = 0, ...options } = {}) {
+  return function ({ insideHTML, indent = 0, ...options } = {}) {
     const output = indentLines(shortcode.call(this, options), { amount: indent })
 
-    return `\n\n${output}\n\n`
+    return insideHTML ? output : `\n\n${output}\n\n`
   }
 }
 

--- a/src/_tests/video/index.md
+++ b/src/_tests/video/index.md
@@ -132,3 +132,16 @@ Define a height for the video player, or calculate the height using an aspect ra
 ## `classes` parameter
 
 Adds custom classes to the video player, for bespoke styling.
+
+## Inside HTML block
+
+When using the shortcode inside an HTML block,
+use the `insideHTML` option to avoid having the `<video>`
+tag wrapped in a `<p>` tag.
+
+{% testExample %}
+
+<div>
+{% video { source: "mp4-h264.mp4", width: 200, insideHTML: true } %}
+</div>
+{% endtestExample %}


### PR DESCRIPTION
When inside an HTML block, the blank line injected around shortcode's output were problematic as it made Markdown it interpret the output as markdown.

In the case of the `video` shortcode, this lead to the `<video>` tags being wrapped in `<p>`, adding extra margin at their bottom.

This PR adds the same `insideHTML` option as the `pairedBlockShortcode` to `blockShortcode` allowing to control whether or not blank lines should be wrapping the output.

Fixes #145 by giving us the ability to control whether or not to output blank lines.

## Thoughts

Rather than automatically removing the blank lines across the board, which may have adverse effect in some places, I prefered an explicit parameter, in line with what paired shortcode already support. This also ensures that when used in the middle of Markdown content, shortcodes like `<video>` get the right spacing by being wrapped inside a `<p>`.

If we see ourselves sprinkling `insideHTML` in many places, we could review this by either:
- making the injection of blank lines opt-in rather than opt-out when the shortcode is called
- letting `blockShortcode` and `pairedBlockShortcode` receive a default for `insideHTML` so specific shortcode could chose to default to having no blank lines
