### PR TITLE
Update colour usage data

### DIFF
--- a/src/_data/colours.js
+++ b/src/_data/colours.js
@@ -122,7 +122,7 @@ export default function () {
       group: 'green',
       hex: '#09442D',
       label: 'Green shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'green',
@@ -178,7 +178,7 @@ export default function () {
       group: 'teal',
       hex: '#0B4144',
       label: 'Teal shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'teal',
@@ -236,7 +236,7 @@ export default function () {
       group: 'purple',
       hex: '#2A1950',
       label: 'Purple shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'purple',
@@ -292,7 +292,7 @@ export default function () {
       group: 'magenta',
       hex: '#651B3E',
       label: 'Magenta shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'magenta',
@@ -348,7 +348,7 @@ export default function () {
       group: 'red',
       hex: '#651B1B',
       label: 'Red shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'red',
@@ -404,7 +404,7 @@ export default function () {
       group: 'orange',
       hex: '#7A3C1C',
       label: 'Orange shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'orange',
@@ -460,7 +460,7 @@ export default function () {
       group: 'yellow',
       hex: '#806F00',
       label: 'Yellow shade 50%',
-      uses: ['app', 'social', 'web']
+      uses: ['app', 'social']
     },
     {
       group: 'yellow',


### PR DESCRIPTION
The colour data file mistakenly lists all 50% shades as being approved for web use. With the exception of blue shade 50%, none of them have not been approved for web use in v1 of the guidelines.

> [!NOTE]
> This has been raised as an issue to the brand team, as we will probably require these 50% shades when implementing the brand in the Design System. Hopefully, they will be available for web use in the next version of the guidelines.