### PR TITLE
Reduce chapter navigation column width

### DIFF
--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -56,8 +56,8 @@
     }) }}
   {%- endif %}
 
-  <div class="govuk-grid-row app-page-wrapper">
-    <nav class="govuk-grid-column-one-third app-chapter-navigation" aria-label="Pages in this section">
+  <div class="app-page-wrapper">
+    <nav class="app-chapter-navigation" aria-label="Pages in this section">
       {% from "link-list.njk" import appLinkList %}
       {{ appLinkList({
         pages: sidebarNavigationRoot.data.children,
@@ -65,7 +65,7 @@
       })}}
     </nav>
 
-    <div class="govuk-grid-column-two-thirds">
+    <div class="app-content">
       {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
       {# Some pages, like test pages, don't have ancestors #}

--- a/src/_stylesheets/_template.scss
+++ b/src/_stylesheets/_template.scss
@@ -8,6 +8,16 @@
 .app-page-wrapper {
   @include govuk-responsive-margin(6, $direction: top);
   @include govuk-responsive-margin(7, $direction: bottom);
+
+  @include govuk-media-query($from: tablet) {
+    display: grid;
+    grid-template-columns: 210px 1fr;
+    gap: $govuk-gutter;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    grid-template-columns: 260px 1fr;
+  }
 }
 
 .app-chapter-navigation {


### PR DESCRIPTION
Makes the chapter navigation column width scale in the same manner as the Design System.

The navigation now resizes at two distinct steps—having a 210 pixel wide content area on tablet breakpoint and 260 pixels wide on desktop breakpoint—instead of fluidly scaling like before.

This has the effect that the navigation is now wider than it was previously on the low end of these breakpoints, and narrower on the wider end of them. This can be seen on the screenshots below.

Closes #136.

## Changes
- Removed use of `.govuk-grid-row` and `.govuk-grid-column` classes.
- Add new styles that replicate the Design System website's chapter navigation width. 

## Screenshots

||Before|After|
|:-|:-:|:-:|
|Full width|<img width="2036" height="1044" alt="image" src="https://github.com/user-attachments/assets/e088d498-5657-4af5-91c7-5e16ec1e3dd9" />|<img width="2036" height="1044" alt="image" src="https://github.com/user-attachments/assets/00826fac-229c-44fb-81fb-649528dbd487" />|
|Narrowest desktop breakpoint|<img width="1538" height="1044" alt="image" src="https://github.com/user-attachments/assets/a47647c6-be70-42a6-809c-60f7d560b206" />|<img width="1538" height="1044" alt="image" src="https://github.com/user-attachments/assets/fde69d42-ccf8-4cb7-a5d7-9c428e09711b" />|
|Narrowest tablet breakpoint|<img width="1290" height="1044" alt="image" src="https://github.com/user-attachments/assets/1276bcb6-0f1f-4bfc-b43f-fb630314ec16" />|<img width="1290" height="1044" alt="image" src="https://github.com/user-attachments/assets/ab1f0011-0b0e-4cbd-95d9-32b6d59dd967" />|