### PR TITLE
Configure cache-control headers for fonts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+# Cache fonts from GOV.UK Frontend with unique fingerprints as immutable
+[[headers]]
+  for = "/assets/fonts/*"
+  [headers.values]
+    Cache-Control = "public,max-age=2147483648,immutable"


### PR DESCRIPTION
By default Netlify serves assets like fonts with the `Cache-Control` header `public,max-age=0,must-revalidate`.

The fonts included in GOV.UK Frontend include a fingerprint in their filename which should be changed if the contents of the font change.

As such we can treat the files as immutable, and instead serve them as `public,max-age=2147483648,immutable`.

As well as a small improvement to performance, removing `must-revalidate` has the benefit of preventing the flash of invisible text currently happening on every page load whilst [the browser revalidates the font assets][1].

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#validation