### PR TITLE
Fix inverse service navigation colours

### DIFF
--- a/src/_stylesheets/_mobile-navigation-section.scss
+++ b/src/_stylesheets/_mobile-navigation-section.scss
@@ -73,6 +73,20 @@ $_govuk-service-navigation-font-size: 19px;
   }
 }
 
+.govuk-template--rebranded .govuk-service-navigation--inverse {
+  // Override mobile menu toggles colour
+  .app-mobile-navigation-section__toggle {
+    border-top-color: $app-blue-tint-50;
+    color: govuk-colour('white');
+  }
+
+  // Override link styles in sub menus
+  .app-mobile-navigation-section__item .govuk-service-navigation__link {
+    @include govuk-link-style-no-visited-state;
+    @include govuk-link-style-no-underline;
+  }
+}
+
 $app-chevron-size: 6px;
 $app-chevron-stroke-width: 2px;
 $app-chevron-width: math.sqrt(2 * math.pow(6, 2));


### PR DESCRIPTION
Fixes the inverse service navigation not having appropriate link and toggle colours on mobile. Closes #168.

## Changes
- Ports the missing inverse service navigation styles from govuk-design-system, mimicking the appearance it uses there. 

## Screenshots

|Before|After|
|:-:|:-:|
|<img width="794" height="1136" alt="Before: Menu with dark blue toggles on a blue background, and white links on a white background when expanded." src="https://github.com/user-attachments/assets/5f02644a-6634-4746-a85d-7ac1fb179e2d" />|<img width="794" height="1136" alt="After: Menu with white toggles on a blue background, and blue links on a white background when expanded." src="https://github.com/user-attachments/assets/163bc5b5-66e8-4ede-85f8-7789bea531f5" />|