### PR TITLE
Various small content fixes

### DIFF
--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -5,7 +5,7 @@ title: GOV.UK is a blue brand
 
 Our core brand colours are Primary blue and Accent teal.
 
-We’re building on the primary blue already in place to support recognition and trust. Using it more consistently will make it a clear visual signature of GOV.UK.
+We’re building on the Primary blue already in place to support recognition and trust. Using it more consistently will make it a clear visual signature of GOV.UK.
 
 Accent teal also sits alongside to add impact and help the brand feel more modern.
 
@@ -74,7 +74,7 @@ Indicative examples for illustrative purposes only.
 
 <div class="app-section-highlight__wrapper--space-around">
 
-![Screenshot of YouTube profile on mobile, showing blue and teal used in the banner image.](./youtube-profile.png)
+![Screenshot of YouTube profile on mobile, showing Primary blue and Accent teal used in the banner image.](./youtube-profile.png)
 
 </div>
 </div>

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -33,7 +33,7 @@ The app splash screen utilises the dot in motion to represent GOV.UK bringing to
 
 ### Video description
 
-No audio. The dot leads a trail of other dots of various colours in a spiral towards the centre of a mobile screen, where it becomes the dot within the GOV.UK logo as it fades and pushes in. The crown logo is revealed by an circular iris effect at the bottom of the screen.
+No audio. The dot leads a trail of other dots of various colours in a spiral towards the centre of a mobile screen, where it becomes the dot within the GOV.UK logo as it fades and pushes in. The crown logo is revealed by a circular iris effect at the bottom of the screen.
 
 ## Illustration
 
@@ -60,7 +60,7 @@ No audio. An animation of a person giving a friendly wave. Circles are used to d
 
 ### Travel
 
-No audio. An animation of luggage moving aross the frame. Suitcases are drawn as rectangles with corners. Circles are used to draw wheels and luggage tags, whilst pieces of a circle are used to draw the handles.
+No audio. An animation of luggage moving aross the frame. Suitcases are drawn as rectangles with rounded corners. Circles are used to draw wheels and luggage tags, whilst pieces of a circle are used to draw the handles.
 
 </div>
 <div>
@@ -216,12 +216,12 @@ Indicative examples for illustrative purposes only.
 </div> 
 <div>
 
-![Instagram post with image saying "Get help with your pension" alongside a graphic of a circular-shaped piggy bank.](./static-dot-2.png)
+![Instagram post with image saying "Register to vote" inside a green circle.](./static-dot-2.png)
 
 </div> 
 <div>
 
-![Instagram post with image saying "Register to vote" inside a green circle.](./static-dot-3.png)
+![Instagram post with image saying "Get help with your pension" alongside a graphic of a circular-shaped piggy bank.](./static-dot-3.png)
 
 </div> 
 <div>

--- a/src/graphic-device/expression/index.md
+++ b/src/graphic-device/expression/index.md
@@ -40,7 +40,7 @@ Indicative examples for illustrative purposes only.
 
 ### Informs
 
-![Infographic showing statistics for the 3 most visited pages on the GOV.UK website.](./expression-informs.png)
+![Infographic showing statistics in circles for the 3 most visited pages on the GOV.UK website.](./expression-informs.png)
 
 </div>
 {% endgrid %}
@@ -113,7 +113,7 @@ No audio. The small dot with a label showing 1% starts growing whilst the percen
 
 ### Transitions
 
-No audio. The dot shown in a title card, where it's the dotted "i" in "Childcare". The dot expands to cover the entire screen, to transition to a second title card with a message to "Apply for 30 hours of government funded childcare"
+No audio. The dot shown in a title card, where it's the dot above the "i" in "Childcare". The dot expands to cover the entire screen, to transition to a second title card with a message to "Apply for 30 hours of government funded childcare".
 
 </div>
 <div>

--- a/src/index.md
+++ b/src/index.md
@@ -16,7 +16,7 @@ mainClasses: 'app-homepage'
 
 We’ve refreshed the GOV.UK brand to meet the needs and changing expectations of users across different channels and contexts.
 
-{{ govukButton({ href: ("/overview/" | url), text: "Find out more", isStartButton: true, classes: "govuk-button--inverse govuk-!-margin-top-5" }) }}
+{{ govukButton({ href: ("/introduction/" | url), text: "Find out more", isStartButton: true, classes: "govuk-button--inverse govuk-!-margin-top-5" }) }}
 
 {% endgridCell %}
 {% endgrid %}

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -1,6 +1,6 @@
 ---
 order: 0
-title: Overview
+title: Introduction
 ---
 
 ## Brand ambition

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -123,7 +123,7 @@ An example of this is the GOV.UK One Login app.
 Framework
 {% endfigure %}
 
-{% figure { src: "./app-icon.svg", alt: "App icon of the GOV.UK app.", classes: "govuk-!-margin-bottom-0" } %}
+{% figure { src: "./app-icon.svg", alt: "App icon of the GOV.UK app. The wordmark is shown above the crown.", classes: "govuk-!-margin-bottom-0" } %}
 **Example 1:** GOV.UK app
 {% endfigure %}
 

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -71,7 +71,6 @@ Indicative examples for illustrative purposes only.
     "/graphic-device/dot-use-examples/splash-screen-short-version.webm"
 ] } %}
 
-<!-- TODO: not sure if this should be the short or long version (both files are in the folder) -->
 </div>
 
 <div>

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -29,7 +29,7 @@ In both horizontal and stacked lock-ups, the space between the wordmark and prod
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 {% gridCell { verticalAlign: "end" } %}
-![Various diagrams of the GOV.UK Pay lock-up in black showing how the dot is used to set spacing between the product name and wordmark. Horizontal and stacked lock-ups are shown. The dot between 'GOV' and 'UK' is Primary blue.](./lockup-1.svg)
+![Various diagrams of the GOV.UK Pay lock-up showing how the dot is used to set spacing between the product name and wordmark. It is one dot between them when horizontally as well as vertically stacked. The shape of the G from the wordmark is showing spacing around the lock-up.](./lockup-1.svg)
 {% endgridCell %}
 
 {% gridCell { verticalAlign: "end" } %}

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -60,7 +60,7 @@ On 14.2pt type, letter spacing should be -0.21 pixels.
 </div>
 {% gridCell { classes: 'app-grid__cell--image-full-width' } %}
 
-![Horizontal lock-ups for GOV.UK Pay, GOV.UK Wallet and GOV.UK Notify. Each lock-up is shown is on a single line.](./horizontal-pay.svg) ![](./horizontal-wallet.svg) ![](./horizontal-notify.svg)
+![Horizontal lock-ups for GOV.UK Pay, GOV.UK Wallet and GOV.UK Notify. Each lock-up is shown on a single line.](./horizontal-pay.svg) ![](./horizontal-wallet.svg) ![](./horizontal-notify.svg)
 
 {% endgridCell %}
 
@@ -73,7 +73,7 @@ Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots 
 </div>
 {% gridCell { classes: 'app-grid__cell--image-full-width' } %}
 
-![Horizontal lock-ups with the crown for GOV.UK Pay, GOV.UK Wallet and GOV.UK Notify. Each lock-up is shown is on a single line after the crown.](./horizontal-with-crown-pay.svg) ![](./horizontal-with-crown-wallet.svg) ![](./horizontal-with-crown-notify.svg)
+![Horizontal lock-ups with the crown for GOV.UK Pay, GOV.UK Wallet and GOV.UK Notify. Each lock-up is shown on a single line after the crown.](./horizontal-with-crown-pay.svg) ![](./horizontal-with-crown-wallet.svg) ![](./horizontal-with-crown-notify.svg)
 
 {% endgridCell %}
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -122,21 +122,21 @@ If it’s too small, it can lose detail and be harder for some users to read or 
 
     {% gridCell %}
 
-    ![The wordmark for "GOV.UK". Minimum width of the wordmark: 50px.](./wordmark-min-width.svg)
+    ![The wordmark for "GOV.UK" with an arrow indicating its minimum width.](./wordmark-min-width.svg)
     Minimum size:</br>
     <strong class="govuk-!-font-size-24">50px</strong>
 
     {% endgridCell %}
     {% gridCell %}
 
-    ![The crown element of the GOV.UK logo. Minimum width of the crown on it own: 16px.](./crown-min-width.svg)
+    ![The crown element of the GOV.UK logo with an arrow indicating its minimum width when it's on its own.](./crown-min-width.svg)
     Minimum size:</br>
     <strong class="govuk-!-font-size-24">16px</strong>
 
     {% endgridCell %}
     {% gridCell { classes: 'govuk-!-margin-bottom-6'} %}
 
-    ![Smaller version of the crown, with adjustments such as fewer dots.](./crown-favicon.svg)
+    ![Smaller version of the crown, with adjustments such as fewer dots, and an arrow indicating its minimum width.](./crown-favicon.svg)
     Use the small crown version for anything below the crown’s minimum size, such as web favicons.
 
     {% endgridCell %}

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -19,7 +19,7 @@ As our primary identifier, the GOV.UK wordmark should be used in all application
 
 ## Crown
 
-As our primary identifier, the GOV.UK wordmark should be used in all applications of the logo.
+The crown should be used as a supporting element that indicates trust and reassurance. It should always appear in close proximity to the wordmark.
 
 [The exception to this rule is the GOV.UK website](/logo-system/web/).
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -149,9 +149,9 @@ If it’s too small, it can lose detail and be harder for some users to read or 
 
 <div class="app-top-border">
 
-### Primary Blue background
+### Primary blue background
 
-When using on a Primary Blue background, the wordmark colour should use White and Accent Teal.
+When using on a Primary blue background, the wordmark colour should use White and Accent teal.
 
 </div>
 <div>
@@ -163,7 +163,7 @@ When using on a Primary Blue background, the wordmark colour should use White an
 
 ### Light background
 
-When using against a light background, the wordmark colour should use Black and Primary Blue.
+When using against a light background, the wordmark colour should use Black and Primary blue.
 
 </div>
 <div>
@@ -175,7 +175,7 @@ When using against a light background, the wordmark colour should use Black and 
 
 ### Special use
 
-When using against a busy background or in print situations where colour is not possible, white or black versions of the wordmark can be used.
+When using against a busy background or in print situations where colour is not possible, White or Black versions of the wordmark can be used.
 
 </div>
 <div>

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -40,8 +40,6 @@ Consistent use of type styles aids clarity and hierarchy.
 
 Headings should be attention-grabbing, whilst body text should prioritize readability with appropriate line spacing and contrast.
 
-<!-- TODO: lots to do here, some of the below should probably be in images -->
-
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div class="app-top-border">
@@ -80,9 +78,6 @@ img goes here
 {% endgrid %}
 
 ## Alignment
-
-<!-- TODO: the next two headings started with a small image that is not in here yet
-           but we might not need it for consistency reasons? -->
 
 {% callout %}
 Indicative examples for illustrative purposes only.


### PR DESCRIPTION
I went through the website and fixed various small things I found:

* Rename Overview page to Introduction
  * Not sure if this is controversial. We said we would rename the page when the mobile menu said "Overview overview". Although that has now been fixed and this change is therefore not necessary for that, I think "Overview" is very badly describing what the page does. And it is called "Introduction" in the original PDF. We could use a different word, just not "Overview".
* Fix some colour names using incorrect letter case
* Remove TODO comments for things that have already been fixed
* Fixed some typos
  * This includes when we have copied the wrong text, forgot a word or mixed up two different descriptions.
* Improve some image and video descriptions
  * This especially needs a review from @calvin-lau-sig7. I will leave a few comments in a bit to explain my changes.
