### PR TITLE
Make some 'image with text list' layouts more consistent

### DIFF
--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -94,11 +94,6 @@ To maintain consistency across channels the colours within our palette should ne
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div>
-
-![](./incorrect-colour-combos.png)
-
-</div>
 <div class="app-top-border">
 
 Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www.w3.org/TR/WCAG22/#contrast-minimum)
@@ -106,7 +101,7 @@ Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www
 </div>
 <div>
 
-![](./incorrect-new-colours.png)
+![](./incorrect-colour-combos.png)
 
 </div>
 <div class="app-top-border">
@@ -116,7 +111,7 @@ Do not create new colours
 </div>
 <div>
 
-![](./incorrect-too-many-colours.png)
+![](./incorrect-new-colours.png)
 
 </div>
 <div class="app-top-border">
@@ -126,12 +121,17 @@ Do not use too many colours within an application
 </div>
 <div>
 
-![](./incorrect-gradients.png)
+![](./incorrect-too-many-colours.png)
 
 </div>
 <div class="app-top-border">
 
 Do not mix colours to create gradients (single colour gradients are permitted for use over imagery)
+
+</div>
+<div>
+
+![](./incorrect-gradients.png)
 
 </div>
 

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -280,58 +280,76 @@ The dot has defined roles and behaviours, set out earlier in this guidance.
 
 To keep things consistent, avoid the following:
 
-{% grid { columns: { mobile: 1, tablet: 2 } } %}
+{% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div>
+<div class="app-top-border">
 
 ### Overuse
 
 Dot not overuse the dot
 
+</div>
+<div>
+
 ![Crossed out graphic with a small blank dot on the top left. Text placed in the centre within a large circle, and also contains a lozenge-shaped text highlight.](./incorrect-overuse.png)
 
 </div>
-<div>
+<div class="app-top-border">
 
 ### Decorative elements
 
 Dot not use the dot in a decorative way
 
+</div>
+<div>
+
 ![Crossed out graphic some text, with a dot placed off-centre in the background.](./incorrect-decorative.png)
 
 </div>
-<div>
+<div class="app-top-border">
 
 ### Distortions
 
 Do not distort or skew the dot
 
+</div>
+<div>
+
 ![Crossed out graphic with some text placed inside a stretched-out oval.](./incorrect-distorted.png)
 
 </div>
-<div>
+<div class="app-top-border">
 
 ### Stroke
 
 Do not use stroke versions of the dot
 
+</div>
+<div>
+
 ![Crossed out graphic of a circular outline, resembling a ring.](./incorrect-stroke.png)
 
 </div>
-<div>
+<div class="app-top-border">
 
 ### Crops
 
 Do not use abstract crops of the dot
 
+</div>
+<div>
+
 ![Crossed out graphic showing only the cropped corner of a large circle.](./incorrect-crop.png)
 
 </div>
-<div>
+<div class="app-top-border">
 
 ### Unapproved filters and effects
 
 Do not apply shadows or gradients
+
+</div>
+<div>
 
 ![Crossed out graphic of a circle with drop shadow.](./incorrect-shadow.png)
 


### PR DESCRIPTION
I noticed that there are two instances of lists of images with text that are not consistent with the rest.
I don't know if that was intentional or not, but here are the changes in case it wasn't.

I have checked these changes against #173 in case that is covered there and it isn't.
Although one of the two instances was touched in there but not to change the layout. If this layout gets accepted, those changes on this specific section would need to be removed again from #173.

## Graphic device > Dot use examples # Incorrect dot usage

<table>
<tr>
<th><a href="https://govuk-brand-guidelines.netlify.app/graphic-device/dot-use-examples/#incorrect-dot-usage">Before</a></th>
<th><a href="TODO">After</a></th>
</tr>
<tr>
<td><img width="705" height="712" alt="Screenshot 2025-09-18 at 18 14 44" src="https://github.com/user-attachments/assets/13e616d2-dd28-48c4-9fda-d15806b0de40" />
</td>
<td><img width="702" height="712" alt="Screenshot 2025-09-18 at 18 15 43" src="https://github.com/user-attachments/assets/40e89eb6-19c4-43a2-9ca5-3ccf90168d82" />
</td>
</tr>
</table>

## Colour > GOV.UK is a blue brand # Incorrect colour usage

<table>
<tr>
<th><a href="https://govuk-brand-guidelines.netlify.app/colour/govuk-blue/#incorrect-colour-usage">Before</a></th>
<th><a href="TODO">After</a></th>
</tr>
<tr>
<td><img width="700" height="677" alt="Screenshot 2025-09-18 at 18 15 14" src="https://github.com/user-attachments/assets/a5ece14d-6c3e-4899-9382-a503e09c4981" />
</td>
<td><img width="701" height="674" alt="Screenshot 2025-09-18 at 18 15 56" src="https://github.com/user-attachments/assets/8466d301-e7df-4218-990c-160327b2aeab" />
</td>
</tr>
</table>