### PR TITLE
Replace `app-top-border` and `app-video-border` with `app-border` plus modifiers

### DIFF
--- a/src/_stylesheets/_border.scss
+++ b/src/_stylesheets/_border.scss
@@ -1,0 +1,11 @@
+.app-border {
+  --app-border-colour: #{$app-blue-shade-25};
+  border: 1px solid var(--app-border-colour);
+}
+
+.app-border--top {
+  padding-top: govuk-spacing(2);
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+}

--- a/src/_stylesheets/_border.scss
+++ b/src/_stylesheets/_border.scss
@@ -1,6 +1,5 @@
 .app-border {
-  --app-border-colour: #{$app-blue-shade-25};
-  border: 1px solid var(--app-border-colour);
+  border: 1px solid $app-blue-shade-25;
 }
 
 .app-border--top {
@@ -11,5 +10,5 @@
 }
 
 .app-border--video {
-  --app-border-colour: #{$govuk-border-colour};
+  border-color: $govuk-border-colour;
 }

--- a/src/_stylesheets/_border.scss
+++ b/src/_stylesheets/_border.scss
@@ -9,3 +9,7 @@
   border-bottom: 0;
   border-left: 0;
 }
+
+.app-border--video {
+  --app-border-colour: #{$govuk-border-colour};
+}

--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -15,19 +15,11 @@
   :last-child {
     margin-bottom: 0;
   }
-
-  .app-top-border {
-    --app-top-border-colour: #{govuk-colour('white')};
-  }
 }
 
 .app-section-highlight--light-blue,
 .app-section-highlight--light-grey {
   color: govuk-colour('black');
-
-  .app-top-border {
-    --app-top-border-colour: #{$app-blue-shade-25};
-  }
 }
 
 .app-section-highlight--light-blue {

--- a/src/_stylesheets/_top-border.scss
+++ b/src/_stylesheets/_top-border.scss
@@ -1,8 +1,0 @@
-// Note: The Section Highlight component overrules --app-top-border-colour
-
-.app-top-border {
-  --app-top-border-colour: #{$app-blue-shade-25};
-
-  padding-top: govuk-spacing(2);
-  border-top: 1px solid var(--app-top-border-colour);
-}

--- a/src/_stylesheets/_video-border.scss
+++ b/src/_stylesheets/_video-border.scss
@@ -1,4 +1,0 @@
-.app-video-border {
-  --app-top-border-colour: #{$govuk-border-colour};
-  border: 1px solid var(--app-top-border-colour);
-}

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -40,7 +40,6 @@
 @import 'mobile-navigation-section';
 @import 'section-highlight';
 @import 'swatch';
-@import 'video-border';
 
 // Per-template overrides
 @import 'homepage';

--- a/src/_stylesheets/stylesheet.scss
+++ b/src/_stylesheets/stylesheet.scss
@@ -26,6 +26,7 @@
 
 // App components
 @import 'aria-current';
+@import 'border';
 @import 'breadcrumbs';
 @import 'break-out';
 @import 'callout';
@@ -39,7 +40,6 @@
 @import 'mobile-navigation-section';
 @import 'section-highlight';
 @import 'swatch';
-@import 'top-border';
 @import 'video-border';
 
 // Per-template overrides

--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -12,7 +12,7 @@ Accent teal also sits alongside to add impact and help the brand feel more moder
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatch { label: "Primary blue", hex: "#1D70B8" } %}
 {% swatch { label: "Accent teal", hex: "#00FFE0" } %}
@@ -80,7 +80,7 @@ To maintain consistency across channels the colours within our palette should ne
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www.w3.org/TR/WCAG22/#contrast-minimum)
 
@@ -91,7 +91,7 @@ Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www
 
 </div>
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not create new colours
 
@@ -102,7 +102,7 @@ Do not create new colours
 
 </div>
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use too many colours within an application
 
@@ -113,7 +113,7 @@ Do not use too many colours within an application
 
 </div>
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not mix colours to create gradients (single colour gradients are permitted for use over imagery)
 

--- a/src/colour/social/index.md
+++ b/src/colour/social/index.md
@@ -104,7 +104,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: tonalColourExamples, group: "example1" } %}
 
@@ -123,7 +123,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: tonalColourExamples, group: "example2" } %}
 
@@ -141,7 +141,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: tonalColourExamples, group: "example3" } %}
 
@@ -198,7 +198,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set1" } %}
 
@@ -216,7 +216,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set2" } %}
 
@@ -234,7 +234,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set3" } %}
 
@@ -252,7 +252,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set4" } %}
 
@@ -270,7 +270,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set5" } %}
 
@@ -288,7 +288,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set6" } %}
 
@@ -306,7 +306,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set7" } %}
 
@@ -324,7 +324,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set8" } %}
 
@@ -342,7 +342,7 @@ Remember, some users browse with high-contrast settings or dark mode. Colours ma
 </div>
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColours, group: "set9" } %}
 
@@ -374,7 +374,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColourExamples, group: "example1" } %}
 
@@ -392,7 +392,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColourExamples, group: "example2" } %}
 
@@ -410,7 +410,7 @@ Indicative examples for illustrative purposes only.
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
 <div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 {% swatchList { palette: companionColourExamples, group: "example3" } %}
 

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -50,7 +50,7 @@ The dot can be brought to life through animation in illustrations, adding person
     {% video { source: [
     "./illustration-wave.mp4",
     "./illustration-wave.webm"
-    ], classes: "app-video-border" } %}
+    ], classes: "app-border app-border--video" } %}
     {% endgridCell %}
     {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Travel
@@ -61,7 +61,7 @@ The dot can be brought to life through animation in illustrations, adding person
     {% video { source: [
     "./thumbnail-illustration-travel.mp4",
     "./illustration-travel.webm"
-    ], classes: "app-video-border" } %}
+    ], classes: "app-border app-border--video" } %}
     {% endgridCell %}
     {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Lock
@@ -72,7 +72,7 @@ The dot can be brought to life through animation in illustrations, adding person
     {% video { source: [
     "./illustration-lock.mp4",
     "./illustration-lock.webm"
-    ], classes: "app-video-border" } %}
+    ], classes: "app-border app-border--video" } %}
     {% endgridCell %}
     {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Onboarding
@@ -83,7 +83,7 @@ The dot can be brought to life through animation in illustrations, adding person
     {% video { source: [
     "./illustration-onboarding.mp4",
     "./illustration-onboarding.webm"
-    ], classes: "app-video-border" } %}
+    ], classes: "app-border app-border--video" } %}
     {% endgridCell %}
     {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Piggy bank
@@ -94,7 +94,7 @@ The dot can be brought to life through animation in illustrations, adding person
     {% video { source: [
     "./illustration-piggy-bank.mp4",
     "./illustration-piggy-bank.webm"
-    ], classes: "app-video-border" } %}
+    ], classes: "app-border app-border--video" } %}
     {% endgridCell %}
 
 {% endgrid %}

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -41,7 +41,7 @@ The dot can be brought to life through animation in illustrations, adding person
 
 {% grid { columns: { mobile: 1, tablet: 2, desktop: 3 }, classes: "govuk-!-padding-bottom-6" } %}
 
-    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-top-border"} %}
+    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Person
 
     No audio. An animation of a person giving a friendly wave. Circles are used to draw the head and hand, whilst pieces of a circle are used to draw the shoulders and hairstyle.
@@ -52,7 +52,7 @@ The dot can be brought to life through animation in illustrations, adding person
     "./illustration-wave.webm"
     ], classes: "app-video-border" } %}
     {% endgridCell %}
-    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-top-border"} %}
+    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Travel
 
     No audio. An animation of luggage moving aross the frame. Suitcases are drawn as rectangles with rounded corners. Circles are used to draw wheels and luggage tags, whilst pieces of a circle are used to draw the handles.
@@ -63,7 +63,7 @@ The dot can be brought to life through animation in illustrations, adding person
     "./illustration-travel.webm"
     ], classes: "app-video-border" } %}
     {% endgridCell %}
-    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-top-border"} %}
+    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Lock
 
     No audio. An animation of a circle-shaped padlock opening and closing.
@@ -74,7 +74,7 @@ The dot can be brought to life through animation in illustrations, adding person
     "./illustration-lock.webm"
     ], classes: "app-video-border" } %}
     {% endgridCell %}
-    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-top-border"} %}
+    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Onboarding
 
     No audio. Animation of various circle-themed icons, including a speech bubble, notification bell, map pin and toggle switch.
@@ -85,7 +85,7 @@ The dot can be brought to life through animation in illustrations, adding person
     "./illustration-onboarding.webm"
     ], classes: "app-video-border" } %}
     {% endgridCell %}
-    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-top-border"} %}
+    {% gridCell {span: {desktop: 2, tablet: 1, mobile: 1}, classes: "app-border app-border--top"} %}
     ### Piggy bank
 
     No audio. Animation of a circle-shaped piggy bank. Several coins drop into the piggy bank before it does a happy shake.
@@ -235,7 +235,7 @@ To keep things consistent, avoid the following:
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Overuse
 
@@ -247,7 +247,7 @@ Do not overuse the dot
 ![Crossed out graphic with a small blank dot on the top left. Text placed in the centre within a large circle, and also contains a lozenge-shaped text highlight.](./incorrect-overuse.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Decorative elements
 
@@ -259,7 +259,7 @@ Do not use the dot in a decorative way
 ![Crossed out graphic some text, with a dot placed off-centre in the background.](./incorrect-decorative.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Distortions
 
@@ -271,7 +271,7 @@ Do not distort or skew the dot
 ![Crossed out graphic with some text placed inside a stretched-out oval.](./incorrect-distorted.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Stroke
 
@@ -283,7 +283,7 @@ Do not use stroke versions of the dot
 ![Crossed out graphic of a circular outline, resembling a ring.](./incorrect-stroke.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Crops
 
@@ -295,7 +295,7 @@ Do not use abstract crops of the dot
 ![Crossed out graphic showing only the cropped corner of a large circle.](./incorrect-crop.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Filters and effects
 

--- a/src/graphic-device/expression/index.md
+++ b/src/graphic-device/expression/index.md
@@ -57,7 +57,7 @@ Indicative examples for illustrative purposes only.
 
 {% grid { columns: { tablet: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Guides
 
@@ -70,7 +70,7 @@ No audio. The dot moves playfully from left to right, pausing briefly at points 
     "./expression-dot-guides.webm"
 ] } %}
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Navigates
 
@@ -83,7 +83,7 @@ No audio. The dot moves in a straight line from left to right across a navigatio
     "./expression-dot-navigates.webm"
 ] } %}
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Highlights
 
@@ -96,7 +96,7 @@ No audio. The dot is shown at the end of a "Don't forget to vote" message as it 
     "./expression-dot-highlights.webm"
 ] } %}
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Informs
 
@@ -109,7 +109,7 @@ No audio. The small dot with a label showing 1% starts growing whilst the percen
     "./expression-dot-informs.webm"
 ] } %}
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Transitions
 
@@ -122,7 +122,7 @@ No audio. The dot shown in a title card, where it's the dot above the "i" in "Ch
     "./expression-dot-transitions.webm"
 ] } %}
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Illustrates
 

--- a/src/logo-system/brand-hierarchy/index.md
+++ b/src/logo-system/brand-hierarchy/index.md
@@ -49,7 +49,7 @@ Use the width and height of the G in the GOV.UK wordmark to set the overall marg
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Horizontal
 
@@ -64,7 +64,7 @@ On 14.2pt type, letter spacing should be -0.21 pixels.
 
 {% endgridCell %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Horizontal with crown
 
@@ -77,7 +77,7 @@ Spacing between wordmark and crown on horizontal lock-up should be 3 crown dots 
 
 {% endgridCell %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Stacked for web
 
@@ -93,7 +93,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 
 {% endgridCell %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Stacked for app
 
@@ -108,7 +108,7 @@ Spacing between wordmark and product name should be 1 large dot or 7 pixels from
 
 {% endgridCell %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Stacked with crown
 

--- a/src/logo-system/index.md
+++ b/src/logo-system/index.md
@@ -15,7 +15,7 @@ The wordmark is our primary GOV.UK identifier, with the crown being used as a su
 
 {% grid { columns: { mobile: 1, desktop: 2 }, classes: 'govuk-!-margin-top-7' } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Wordmark
 
@@ -27,7 +27,7 @@ Our wordmark is our primary identifier and should be used as the lead asset on t
 ![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Crown
 
@@ -39,7 +39,7 @@ The crown must always be present but is used as a supporting asset within close 
 ![The crown element of the GOV.UK logo.](./crown.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Lock-up
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -63,7 +63,7 @@ The size of the crown can be adjusted depending on context. For example, when be
 
 {% grid { columns: { mobile: 1, desktop: 2 }, classes: 'govuk-!-margin-top-6 govuk-!-margin-bottom-6' } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 #### Standard crown size
 
@@ -76,7 +76,7 @@ Wordmark dot = 2× crown dot
 ![Dots from the crown are used to show the correct size of the dot in the wordmark.](./standard-crown.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 #### Enlarged crown size
 
@@ -147,7 +147,7 @@ If it’s too small, it can lose detail and be harder for some users to read or 
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Primary blue background
 
@@ -159,7 +159,7 @@ When using on a Primary blue background, the wordmark colour should use White an
 ![](./logo-primary.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Light background
 
@@ -171,7 +171,7 @@ When using against a light background, the wordmark colour should use Black and 
 ![](./logo-light.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Special use
 
@@ -216,7 +216,7 @@ To maintain consistency across channels the logo elements should never be change
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not alter colour balance within the wordmark
 
@@ -226,7 +226,7 @@ Do not alter colour balance within the wordmark
 ![](./incorrect-altered-colours.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not distort, stretch or skew the wordmark
 
@@ -236,7 +236,7 @@ Do not distort, stretch or skew the wordmark
 ![](./incorrect-squashed.svg)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not apply drop shadows or effects to the wordmark
 
@@ -246,7 +246,7 @@ Do not apply drop shadows or effects to the wordmark
 ![](./incorrect-effects.png)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use the wordmark on overly busy or low-contrast backgrounds
 
@@ -256,7 +256,7 @@ Do not use the wordmark on overly busy or low-contrast backgrounds
 ![](./incorrect-busy.png)
 
 </div>
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not flip, mirror, or rotate the wordmark
 

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -136,7 +136,7 @@ To aid brand recognition and coherency, adaptive dot colour should not be used w
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use colour combinations that are not accessible.
 
@@ -148,7 +148,7 @@ Do not use colour combinations that are not accessible.
 
 {% endgridCell %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use colour combinations that lack contrast between the wordmark and dot.
 
@@ -160,7 +160,7 @@ Do not use colour combinations that lack contrast between the wordmark and dot.
 
 {% endgridCell%}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 Do not use colour combinations that are not from the same tonal range.
 

--- a/src/typography/social/index.md
+++ b/src/typography/social/index.md
@@ -33,7 +33,7 @@ Headings should be attention-grabbing, whilst body text should prioritize readab
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-{% gridCell {classes: "app-top-border"} %}
+{% gridCell {classes: "app-border app-border--top"} %}
 
 ### Headline styles
 
@@ -47,7 +47,7 @@ Headlines should be bold or light over a maximum of 5 lines. Any content over 5 
 {% endgridCell %}
 {% endgrid %}
 
-{% grid { columns: { mobile: 1, desktop: 2 }, classes: "app-top-border" } %}
+{% grid { columns: { mobile: 1, desktop: 2 }, classes: "app-border app-border--top" } %}
 
 {% gridCell %}
 
@@ -60,7 +60,7 @@ Body copy styles should always be set in Light and should be used for all longer
 {% endgridCell %}
 {% endgrid %}
 
-{% grid { columns: { mobile: 1, desktop: 2 }, classes: "app-top-border" } %}
+{% grid { columns: { mobile: 1, desktop: 2 }, classes: "app-border app-border--top" } %}
 {% gridCell %}
 
 ### Tags styles
@@ -80,7 +80,7 @@ Indicative examples for illustrative purposes only.
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Left aligned text
 
@@ -94,7 +94,7 @@ It prevents uneven gaps (rivers of white space) found in fully justified text, m
 
 ![](./left-aligned.png)
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 ### Centre aligned text
 
@@ -121,7 +121,7 @@ Indicative examples for illustrative purposes only.
 
 {% grid { columns: { mobile: 2, desktop: 2 } } %}
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 **Do** use consistent and clear line and letter spacing.
 
@@ -129,7 +129,7 @@ Indicative examples for illustrative purposes only.
 
 ![](./type-settings-do.svg)
 
-<div class="app-top-border">
+<div class="app-border app-border--top">
 
 **Don't** use line and letter spacing that is too wide or tight.
 


### PR DESCRIPTION
## Change

What it says in the title. Additionally removes the overrides in `_section-highlight` as we aren't using any borders in section highlights anymore

This means we're technically serving more html but the CSS is more sensible as it puts our border styling in one place.

Resolves https://github.com/alphagov/govuk-brand-guidelines/issues/187

## Thoughts

Neither `app-border` nor `app-top-border` nor `app-video-border` really follow BEM as they're not discrete elements but modifiers in and of themselves, so I'm not super happy with this solution from a purity perspective. One idea is to use govuk-frontend's tailwind-esque modifier class system as additions to existing things. So instead of `app-border app-border--top` it'd be just `app-border-top`. I'm not totally sure how much difference it'd make.