### PR TITLE
Remove rendering of section navigation when no links are present

### DIFF
--- a/src/_layouts/generic.njk
+++ b/src/_layouts/generic.njk
@@ -19,20 +19,22 @@
   {% endif %}
 {% endblock %}
 
+{% set hasSidebarNavigation = sidebarNavigationRoot.data.children | length %}
+
 {% block beforeContent %}
   {{ super() }}
 
-  <div class="app-page-wrapper">
-    <nav class="app-chapter-navigation" aria-labelledby="side-navigation">
-      {% if sidebarNavigationRoot.data.children | length %}
+  <div class="{{ ['app-page-wrapper', 'app-page-wrapper--no-navigation' if not hasSidebarNavigation] | select(truthy) | join(' ')}}">
+    {% if hasSidebarNavigation %}
+      <nav class="app-chapter-navigation" aria-labelledby="side-navigation">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1{{ ' govuk-!-margin-top-6' if landing else '' }}" id="side-navigation">In this section</h2>
-      {% endif %}
-      {% from "link-list.njk" import appLinkList %}
-      {{ appLinkList({
-        pages: sidebarNavigationRoot.data.children,
-        renderedPageUrl: page.url
-      })}}
-    </nav>
+        {% from "link-list.njk" import appLinkList %}
+        {{ appLinkList({
+          pages: sidebarNavigationRoot.data.children,
+          renderedPageUrl: page.url
+        })}}
+      </nav>
+    {% endif %}
     {%  set contentClasses = 'app-content app-content--section-' + page.fileSlug  if landing else 'app-content' %}
     <div class="{{ contentClasses }}">
       {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
@@ -71,7 +73,7 @@
 
   {# Render the list of pages under each chapter after the content
     as a fallback for mobile navigation if JavaScript does not load #}
-  {% if isSidebarNavigationRoot and sidebarNavigationRoot.data.children | length %}
+  {% if isSidebarNavigationRoot and hasSidebarNavigation %}
     <nav class="app-chapter-navigation--mobile-fallback" aria-labelledby="chapter-navigation">
       <h2 class="govuk-heading-l" id="chapter-navigation">Pages in {{title}}</h2>
       {% from "link-list.njk" import appLinkList %}

--- a/src/_stylesheets/_template.scss
+++ b/src/_stylesheets/_template.scss
@@ -20,6 +20,14 @@
   }
 }
 
+// When no navigation is present, cancel the grid
+// and limit the width so the content doesn't go larger
+// than how it appears on desktop
+.app-page-wrapper--no-navigation {
+  display: block;
+  max-width: $govuk-page-width - $app-sidebar-nav-desktop;
+}
+
 .app-chapter-navigation {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
Fixes #189 when there are no pages in the section navigation, like on [the Overview page](https://deploy-preview-197--govuk-brand-guidelines.netlify.app/overview/):
- removing the fallback displayed on each section's landing page
- removing the empty `<nav>` and shifting the content to the left of the page

## Thoughts

Not a big fan of having to add a `--no-navigation` modifier for the `app-page-wrapper` block to shift the column left, but couldn't find a grid syntax that would cater for both the one and two column layout while allowing to control the width of the sidebar. All in all, it's probably simpler to have an extra modifier to manage in HTML than a clever `grid-template-columns`, though.