### PR TITLE
Progressively enhance background colour of landing pages

### DIFF
--- a/src/_stylesheets/_landing.scss
+++ b/src/_stylesheets/_landing.scss
@@ -90,6 +90,8 @@
   @extend %app-landing-hero-bleed;
   min-height: govuk-em(410px, 16px);
   padding: 0 govuk-spacing(3) govuk-spacing(6);
+  // fallback for older browsers or users who disable images
+  background-color: var(--app-landing-hero-dark-colour);
   // Image plus a fake gradient to create a flat 2-colour effect
   background-image:
     var(--app-landing-hero-graphic),


### PR DESCRIPTION
I noticed that the hero section on landing pages would show white text on a white background when I disabled images (for testing purposes). This adds a fallback background colour for older browsers or when users choose to disable images so the text is still readable.