### PR TITLE
Small content fixes

### DIFF
--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -96,7 +96,7 @@ Do not use colour combinations that do not meet [WCAG2.2 guidelines](https://www
 
 <div class="app-border app-border--top">
 
-Do not create new colours
+Do not create new colours.
 
 </div>
 <div>
@@ -107,7 +107,7 @@ Do not create new colours
 
 <div class="app-border app-border--top">
 
-Do not use too many colours within an application
+Do not use too many colours within an application.
 
 </div>
 <div>
@@ -118,7 +118,7 @@ Do not use too many colours within an application
 
 <div class="app-border app-border--top">
 
-Do not mix colours to create gradients (single colour gradients are permitted for use over imagery)
+Do not mix colours to create gradients (single colour gradients are permitted for use over imagery).
 
 </div>
 <div>

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -239,7 +239,7 @@ To keep things consistent, avoid the following:
 
 ### Overuse
 
-Do not overuse the dot
+Do not overuse the dot.
 
 </div>
 <div>
@@ -251,7 +251,7 @@ Do not overuse the dot
 
 ### Decorative elements
 
-Do not use the dot in a decorative way
+Do not use the dot in a decorative way.
 
 </div>
 <div>
@@ -263,7 +263,7 @@ Do not use the dot in a decorative way
 
 ### Distortions
 
-Do not distort or skew the dot
+Do not distort or skew the dot.
 
 </div>
 <div>
@@ -275,7 +275,7 @@ Do not distort or skew the dot
 
 ### Stroke
 
-Do not use stroke versions of the dot
+Do not use stroke versions of the dot.
 
 </div>
 <div>
@@ -287,7 +287,7 @@ Do not use stroke versions of the dot
 
 ### Crops
 
-Do not use abstract crops of the dot
+Do not use abstract crops of the dot.
 
 </div>
 <div>
@@ -299,7 +299,7 @@ Do not use abstract crops of the dot
 
 ### Filters and effects
 
-Do not apply shadows or gradients
+Do not apply shadows or gradients.
 
 </div>
 <div>

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -174,7 +174,7 @@ Indicative examples for illustrative purposes only.
 Get help with...
 {% endfigure %}
 {% figure { src: "./video-thumb-influencer.png", alt: "A video thumbnail for 'How I learnt to drive. A smiling young adult is shown in front of a purple background, with the title in a dark purple circle." } %}
-Influencer/presenter
+Influencer / presenter
 {% endfigure %}
 {% endinformInspire %}
 

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -9,8 +9,11 @@ In GOV.UK apps we follow the primary logo system, using the wordmark as the main
 
 An example of this is the GOV.UK app icon.
 
+<!-- The &shy; is intentionally between 'Word' and 'mark' because
+     otherwise the column gets too wide and therefore uneven in mobile view -->
+
 {% grid { columns: 3 } %}
-{% gridCell {verticalAlign: 'end'} %} ### Wordmark
+{% gridCell {verticalAlign: 'end'} %} ### Word&shy;mark
 
     ![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark-on-blue.svg)
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -123,6 +123,7 @@ If it’s too small, it can lose detail and be harder for some users to read or 
     {% gridCell %}
 
     ![The wordmark for "GOV.UK" with an arrow indicating its minimum width.](./wordmark-min-width.svg)
+
     Minimum size:</br>
     <strong class="govuk-!-font-size-24">50px</strong>
 
@@ -130,6 +131,7 @@ If it’s too small, it can lose detail and be harder for some users to read or 
     {% gridCell %}
 
     ![The crown element of the GOV.UK logo with an arrow indicating its minimum width when it's on its own.](./crown-min-width.svg)
+
     Minimum size:</br>
     <strong class="govuk-!-font-size-24">16px</strong>
 
@@ -137,6 +139,7 @@ If it’s too small, it can lose detail and be harder for some users to read or 
     {% gridCell { classes: 'govuk-!-margin-bottom-6'} %}
 
     ![Smaller version of the crown, with adjustments such as fewer dots, and an arrow indicating its minimum width.](./crown-favicon.svg)
+
     Use the small crown version for anything below the crown’s minimum size, such as web favicons.
 
     {% endgridCell %}

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -221,7 +221,7 @@ To maintain consistency across channels the logo elements should never be change
 
 <div class="app-border app-border--top">
 
-Do not alter colour balance within the wordmark
+Do not alter colour balance within the wordmark.
 
 </div>
 <div>
@@ -231,7 +231,7 @@ Do not alter colour balance within the wordmark
 </div>
 <div class="app-border app-border--top">
 
-Do not distort, stretch or skew the wordmark
+Do not distort, stretch or skew the wordmark.
 
 </div>
 <div>
@@ -241,7 +241,7 @@ Do not distort, stretch or skew the wordmark
 </div>
 <div class="app-border app-border--top">
 
-Do not apply drop shadows or effects to the wordmark
+Do not apply drop shadows or effects to the wordmark.
 
 </div>
 <div>
@@ -251,7 +251,7 @@ Do not apply drop shadows or effects to the wordmark
 </div>
 <div class="app-border app-border--top">
 
-Do not use the wordmark on overly busy or low-contrast backgrounds
+Do not use the wordmark on overly busy or low-contrast backgrounds.
 
 </div>
 <div>
@@ -261,7 +261,7 @@ Do not use the wordmark on overly busy or low-contrast backgrounds
 </div>
 <div class="app-border app-border--top">
 
-Do not flip, mirror, or rotate the wordmark
+Do not flip, mirror, or rotate the wordmark.
 
 </div>
 <div>

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -122,17 +122,17 @@ If it’s too small, it can lose detail and be harder for some users to read or 
 
     {% gridCell %}
 
-    ![The wordmark for "GOV.UK" with an arrow indicating its minimum width.](./wordmark-min-width.svg)
+    ![](./wordmark-min-width.svg)
 
-    Minimum size:</br>
+    Wordmark minimum width:</br>
     <strong class="govuk-!-font-size-24">50px</strong>
 
     {% endgridCell %}
     {% gridCell %}
 
-    ![The crown element of the GOV.UK logo with an arrow indicating its minimum width when it's on its own.](./crown-min-width.svg)
+    ![](./crown-min-width.svg)
 
-    Minimum size:</br>
+    Crown minimum width:</br>
     <strong class="govuk-!-font-size-24">16px</strong>
 
     {% endgridCell %}

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -9,8 +9,11 @@ Within GOV.UK social channels we follow the primary logo system, using the wordm
 
 An example of this is in profile icons.
 
+<!-- The &shy; is intentionally between 'Word' and 'mark' because
+     otherwise the column gets too wide and therefore uneven in mobile view -->
+
 {% grid { columns: 3 } %}
-{% gridCell {verticalAlign: 'end'} %} ### Wordmark
+{% gridCell {verticalAlign: 'end'} %} ### Word&shy;mark
 
     ![Wordmark for GOV.UK in white. The dot between 'GOV' and 'UK' is Accent teal and vertically-centred. Shown on a Primary blue background.](./wordmark-on-blue.svg)
 


### PR DESCRIPTION
A couple of small content fixes, some of which fix something visually:

* Add full stop to end of incorrect usage sentences
* Fix uneven columns when a word is too long (#188)
* Add spacing to minimum sizing section
  * I noticed that we don't use our usual spacing here because the images are inline with the text right after it. I assume that was unintentional.
* Add missing important information about minimum sizing to body copy
  * We had discussed this before. I don't know if we intentionally didn't change it or just forgot about it. This is one of those cases where important information in the image needs to be in the body copy.

The visuals of the third and fourth of those...

## Before

<img width="697" height="304" alt="less spacing and only saying 'minimum size'" src="https://github.com/user-attachments/assets/5e487491-f23d-47f8-93bf-1e357fce24bd" />

## After

<img width="694" height="317" alt="more spacing and saying the type of size for what" src="https://github.com/user-attachments/assets/b039e4d1-4517-4520-9412-56f7207fed7d" />