### PR TITLE
Fix breadcrumbs appearing reversed

### DIFF
--- a/eleventy/navigation.js
+++ b/eleventy/navigation.js
@@ -145,9 +145,11 @@ function getAncestors(page) {
  * @returns
  */
 function buildPageTitle(page) {
+  // Reverse a copy of page.data.ancestors rather than changing it directly,
+  // as reverse manipulates arrays in-place
+  const ancestors = [...page.data.ancestors].reverse()
+
   return [page.data.title]
-    .concat(
-      page.data.ancestors.reverse().map((ancestor) => ancestor.data.title)
-    )
+    .concat(ancestors.map((ancestor) => ancestor.data.title))
     .join(' - ')
 }


### PR DESCRIPTION
JavaScript's `reverse` method works in-place (it manipulates the array directly, rather than creating a clone of it). This meant that the `buildPageTitle` function was reversing the array for all following uses. Fixes #201.

## Changes
- Updated `buildPageTitle` to  makes a copy of the array, using spread syntax, prior to reversing it.