### PR TITLE
Disable user agent phone number detection

### DIFF
--- a/src/_layouts/_base.njk
+++ b/src/_layouts/_base.njk
@@ -6,11 +6,19 @@
 
 {% block head %}
   {{ super() }}
+
   {#- Prevent search engine indexing for archive, preview and development builds -#}
   {% if site.env.CONTEXT !== "production" or metadata.noRobots %}
     <meta name="robots" content="noindex, nofollow">
   {% endif %}
+
+  {#- Prevent operating systems interpreting RGB values as phone numbers -#}
+  <meta name="format-detection" content="telephone=no">
+
+  {#- Import brand guidelines stylesheet -#}
   <link rel="stylesheet" href="{{ '/assets/stylesheet.css' | url }}">
+
+  {#- Bundled per-page CSS -#}
   {% getBundle "css" %}
 {% endblock %}
 


### PR DESCRIPTION
Disables the phone number detection feature of some browsers, which is falsely detecting RGB values as being phone numbers. Closes #202. 