### PR TITLE
Fix logos within section highlights not being zoomable

### DIFF
--- a/src/_stylesheets/_section-highlight.scss
+++ b/src/_stylesheets/_section-highlight.scss
@@ -41,7 +41,8 @@
   text-align: center;
 
   img {
-    max-width: 60%;
+    width: 366px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Fixes logos contained within section highlights not getting larger when the page is zoomed.

This was because the maximum size of these images was being constrained to 60% of the section highlight container. When zooming in, the container's padding would increase in size, reducing the available width inside of it, and thus unexpectantly making the image smaller. 

This fixes the issue by instead giving images a fixed initial width that they won't grow larger than (366px was equivalent to 60% of the internal width of the container), whilst still disallowing them from getting larger than the internal width, so that they don't break out of the containers on narrower screens. 

Fixes part of #223.
