### PR TITLE
Add missing video descriptions

### DIFF
--- a/src/colour/govuk-blue/index.md
+++ b/src/colour/govuk-blue/index.md
@@ -47,16 +47,6 @@ Indicative examples for illustrative purposes only.
 
 <div>
 
-### App splash screen
-
-{% video { source: [
-    "/graphic-device/dot-use-examples/splash-screen-long-version.mp4",
-    "/graphic-device/dot-use-examples/splash-screen-long-version.webm"
-] } %}
-
-</div>
-<div>
-
 ### App header
 
 ![Screenshot of GOV.UK app, showing the Primary blue app header with the wordmark in white and the dot in Accent teal.](./app-header.png)
@@ -69,7 +59,25 @@ Indicative examples for illustrative purposes only.
 ![Screenshot of YouTube profile on mobile, showing Primary blue and Accent teal used in the banner image.](./youtube-example.png)
 
 </div>
+
+<div>
+
+### App splash screen
+
+{% video { source: [
+    "/graphic-device/dot-use-examples/splash-screen-long-version.mp4",
+    "/graphic-device/dot-use-examples/splash-screen-long-version.webm"
+] } %}
+
+</div>
+
 {% endgrid %}
+
+#### Video description of app splash screen
+
+No audio. The dot leads a trail of other dots of various colours in a spiral towards the centre of a mobile screen, where it becomes the dot within the GOV.UK logo as it fades and pushes in.
+
+At the bottom of the screen, the crown logo element is revealed by a circular iris effect at the bottom of the screen as the dots in the crown rise and fan out.
 
 ## Colour accessibility
 

--- a/src/graphic-device/dot-use-examples/index.md
+++ b/src/graphic-device/dot-use-examples/index.md
@@ -10,8 +10,8 @@ The app splash screen utilises the dot in motion to represent GOV.UK bringing to
 {% grid { columns: { desktop: 2 } } %}
 
 <div>
-    
- ### Long splash screen
+
+### Long splash screen
 
 {% video { source: [
     "./splash-screen-long-version.mp4",
@@ -31,9 +31,11 @@ The app splash screen utilises the dot in motion to represent GOV.UK bringing to
 </div>
 {% endgrid %}
 
-### Video description
+### Video description of long and short splash screens
 
 No audio. The dot leads a trail of other dots of various colours in a spiral towards the centre of a mobile screen, where it becomes the dot within the GOV.UK logo as it fades and pushes in. The crown logo is revealed by a circular iris effect at the bottom of the screen.
+
+In the long version, the trail of dots moves in a wider spiral.
 
 ## Illustration
 
@@ -192,17 +194,17 @@ Indicative examples for illustrative purposes only.
 
 ![Instagram post with image saying "Today is the Summer bank holiday" alongside a graphic of the sun, made up of a yellow circle with yellow half circles as sun rays.](./static-dot-1.png)
 
-</div> 
+</div>
 <div>
 
 ![Instagram post with image saying "Register to vote" inside a green circle.](./static-dot-2.png)
 
-</div> 
+</div>
 <div>
 
 ![Instagram post with image saying "Get help with your pension" alongside a graphic of a circular-shaped piggy bank.](./static-dot-3.png)
 
-</div> 
+</div>
 <div>
 
 ![Instagram post with image saying "Here's how I got my driving licence" with various circular and rounded-corner graphics. "Driving license" is in a lozenge-shaped highlight.](./static-dot-4.png)

--- a/src/logo-system/app/index.md
+++ b/src/logo-system/app/index.md
@@ -46,6 +46,14 @@ Indicative examples for illustrative purposes only.
 
 <div>
 
+### Crown watermark
+
+![Screenshot of the GOV.UK app, showing the GOV.UK wordmark centred in the top header and the crown watermark centred at the end of a page.](./app-watermark-example.png)
+
+</div>
+
+<div>
+
 ### App splash screen
 
 {% video { source: [
@@ -55,15 +63,13 @@ Indicative examples for illustrative purposes only.
 
 </div>
 
-<div>
-
-### Crown watermark
-
-![Screenshot of the GOV.UK app, showing the GOV.UK wordmark centred in the top header and the crown watermark centred at the end of a page.](./app-watermark-example.png)
-
-</div>
-
 {% endgrid %}
+
+#### Video description of app splash screen
+
+No audio. The dot leads a trail of other dots of various colours in a spiral towards the centre of a mobile screen, where it becomes the dot within the GOV.UK logo as it fades and pushes in.
+
+At the bottom of the screen, the crown logo element is revealed by a circular iris effect at the bottom of the screen as the dots in the crown rise and fan out.
 
 ## App icon
 

--- a/src/logo-system/logo-elements/index.md
+++ b/src/logo-system/logo-elements/index.md
@@ -194,7 +194,7 @@ Both logo elements have a standalone animation that can be used to add dynamism 
 
 {% grid { columns: { mobile: 1, desktop: 2 } } %}
 
-<div>
+    {% gridCell %}
 
 ### Wordmark
 
@@ -203,8 +203,11 @@ Both logo elements have a standalone animation that can be used to add dynamism 
     "./wordmark-motion.webm"
 ] } %}
 
-</div>
-<div>
+No audio. The dot fades in first. Then, GOV and UK fades and pushes in slightly from the left and right, forming the GOV.UK wordmark.
+
+    {% endgridCell %}
+
+    {% gridCell %}
 
 ### Crown
 
@@ -213,7 +216,10 @@ Both logo elements have a standalone animation that can be used to add dynamism 
     "./crown-motion.webm"
 ] } %}
 
-</div>
+No audio. The crown logo element is revealed by a circular iris effect at the bottom of the screen as the dots in the crown rise and fan out.
+
+    {% endgridCell %}
+
 {% endgrid %}
 
 ## Incorrect usage

--- a/src/logo-system/social/index.md
+++ b/src/logo-system/social/index.md
@@ -67,6 +67,8 @@ Indicative examples for illustrative purposes only.
 
 Social end frames can be used at the end of animated or filmed content. They incorporate both the wordmark and crown and act as a branded sign-off.
 
+No audio. In this series of videos, the dot leads a trail of other dots of various colours in a spiral towards the centre of a widescreen, where it becomes the dot within the GOV.UK logo as it fades and pushes in. The crown logo element is revealed by a circular iris effect at the bottom of the screen as the dots in the crown rise and fan out.
+
 ### Video end frame 16:9
 
 {% video { source: [


### PR DESCRIPTION
These changes add video descriptions into videos, mostly where it's needed to be done as part of page content.

There's also a separate commit where I've added more descriptive headings for descriptions, as some of them are placed in slightly less obvious places where images and videos are shown together in a grid.