### PR TITLE
Fix VoiceOver listing mobile menu toggles on desktop

### DIFF
--- a/src/_javascript/mobile-navigation-section.js
+++ b/src/_javascript/mobile-navigation-section.js
@@ -108,14 +108,53 @@ export class MobileNavigationSection extends Component {
       if (this.expanded) {
         this.$subnav.removeAttribute('hidden')
       }
-      this.$button.removeAttribute('hidden')
+      removeAttributes(this.$button, Object.keys(attributesForHidingButton))
     } else {
       this.$root.parentElement.classList.remove(
         'app-mobile-navigation-section__service-navigation-item'
       )
-      this.$button.setAttribute('hidden', '')
+      setAttributes(this.$button, attributesForHidingButton)
       this.$subnav.setAttribute('hidden', '')
       this.$root.removeAttribute('hidden')
     }
+  }
+}
+
+/**
+ * Collection of attributes that needs setting on a `<button>`
+ * to fully hide it, both visually and from screen-readers,
+ * and prevent its activation while hidden
+ */
+const attributesForHidingButton = {
+  hidden: '',
+  // Prevent activating the button with JavaScript APIs while hidden
+  disabled: '',
+  // Fix button still appearing in VoiceOver's form control's menu despite being hidden,
+  // as well as remaining focusable through VoiceOver on iPadOS and iOS
+  // https://bugs.webkit.org/show_bug.cgi?id=300899
+  'aria-hidden': 'true'
+}
+
+/**
+ * Sets a group of attributes on the given element
+ *
+ * @param {Element} $element - The element to set the attribute on
+ * @param {{[attributeName: string]: string}} attributes - The attributes to set
+ */
+function setAttributes($element, attributes) {
+  for (const attributeName in attributes) {
+    $element.setAttribute(attributeName, attributes[attributeName])
+  }
+}
+
+/**
+ * Removes a list of attributes from the given element
+ *
+ * @param {Element} $element - The element to remove the attributes from
+ * @param {string[]} attributeNames - The names of the attributes to remove
+ */
+function removeAttributes($element, attributeNames) {
+  for (const attributeName of attributeNames) {
+    $element.removeAttribute(attributeName)
   }
 }


### PR DESCRIPTION
Ports https://github.com/alphagov/govuk-design-system/pull/4892 to partially fix https://github.com/alphagov/govuk-brand-guidelines/issues/138. Buttons for showing/hiding the mobile menu sections should now no longer be listed in VoiceOver's rotor (on desktop) and no longer be focusable through VoiceOver on iOS.

To fully fix #138, we'll need [this issue](https://github.com/alphagov/govuk-frontend/issues/6294) to be resolved in GOV.UK Frontend and the brand guidelines to use a version of GOV.UK Frontend with the fix.

| Before | After |
|--------|--------|
|  <img width="1512" height="982" alt="VoiceOver rotor on site's homepage showing 4 'collapsed button' items" src="https://github.com/user-attachments/assets/83265c6f-fdf2-4d28-9bd1-67498660d17b" /> | <img width="1512" height="982" alt="VoiceOver rotor on site's homepage not showing 4 'collapsed button' items" src="https://github.com/user-attachments/assets/33c9ad40-5aa1-43ec-957e-fed6670769a8" /> (last two rotor entries are Netlify's preview bar)|

> [!NOTE]
> Given the markup, only the buttons have extra aria attributes. The other hidden elements from that component are:
> * the list of links for each sub-section of the navigation => the content is not listed in the 'Links' section of the rotor
> * the link for each section that appears on desktop => they are not listed in the 'Links' section of the rotor either
>
> That makes me think we're OK in terms of what Voice Over sees



