### PR TITLE
Remove TODOs from test page

### DIFF
--- a/src/_tests/inform-inspire/index.md
+++ b/src/_tests/inform-inspire/index.md
@@ -28,13 +28,13 @@ Influencer/presenter
 ## Inform inspire with flex container, 5 items and list
 
 {% informInspire { contentClasses: 'app-inform-inspire__content--flex app-inform-inspire__content--flex-5-items', list: ['black and white', 'dark shade', 'Primary blue', 'tonal colour', 'companion colour'], listLabel: 'Colour use options (from left to right):' } %}
-![TODO](./tone-black-and-white.png)
+![](./tone-black-and-white.png)
 
-![TODO](./tone-dark-shade.png)
+![](./tone-dark-shade.png)
 
-![TODO](./tone-primary-blue.png)
+![](./tone-primary-blue.png)
 
-![TODO](./tone-tonal-colour.png)
+![](./tone-tonal-colour.png)
 
-![TODO](./tone-companion-colour.png)
+![](./tone-companion-colour.png)
 {% endinformInspire %}


### PR DESCRIPTION
Whenever I search for "todo" in the code I find these occurrences that are on test pages. They are not there because there is anything to do but because the code was copied from an earlier version that had images that still had alt text to be written. This removes those "TODOs" so it's less confusing and time-consuming to find things that are actually to do.