### PR TITLE
Typography spacing changes

### DIFF
--- a/src/_stylesheets/_prose.scss
+++ b/src/_stylesheets/_prose.scss
@@ -1,3 +1,28 @@
+//
+// Override spacing from GOV.UK Frontend
+//
+
+.govuk-heading-l,
+.govuk-heading-m {
+  margin-bottom: govuk-spacing(2);
+  padding-top: 0;
+}
+
+.govuk-body + .govuk-heading-l,
+.govuk-list + .govuk-heading-l {
+  margin-top: govuk-spacing(7);
+}
+
+.govuk-table,
+.govuk-body + .app-grid,
+.govuk-list + .app-grid {
+  margin-top: govuk-spacing(7);
+}
+
+//
+// Media
+//
+
 .app-prose img,
 .app-prose video {
   max-width: 100%;
@@ -8,6 +33,10 @@
   width: auto;
   max-height: 90vh;
 }
+
+//
+// Code blocks
+//
 
 .app-prose code {
   padding-right: govuk-spacing(1);


### PR DESCRIPTION
Changes to spacing around heading, paragraphs, lists and tables, as described in #336.

The code here is a little different but should have the same end result, visually. 

Closes #336.

## Changes

### Headings 
- Removed top padding on large (`h2`) and medium (`h3`) headings .
- Added 40px of top margin to large headings that come directly after a paragraph or list.
- Increased bottom margin of large headings from 5px to 10px.
- Increased bottom margin to medium headings from 0 to 10px.

### Other components
- Added 40px of top margin to tables.
- Added 40px of top margin to grids that come directly after a paragraph or list.

## Thoughts

We've bounced between having 15px, 20px or 25px of margin below paragraphs. This PR uses 20px (the same as in Frontend) as Slack discussion felt that 25px was too much space and 15px was too close to the 10px of margin that come after headings. 

