### PR TITLE
Update govuk-frontend from 5.13.0 to 5.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-promise": "^7.2.1",
         "glob": "^13.0.0",
         "globals": "^17.3.0",
-        "govuk-frontend": "^5.13.0",
+        "govuk-frontend": "^5.14.0",
         "html-validate": "^10.7.0",
         "husky": "^9.1.7",
         "linkinator": "^7.5.3",
@@ -7987,9 +7987,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
-      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
+      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-promise": "^7.2.1",
     "glob": "^13.0.0",
     "globals": "^17.3.0",
-    "govuk-frontend": "^5.13.0",
+    "govuk-frontend": "^5.14.0",
     "html-validate": "^10.7.0",
     "husky": "^9.1.7",
     "linkinator": "^7.5.3",


### PR DESCRIPTION
Dependabot's PR for this was a little wonky, so I'm doing it manually. 

We're consciously not updating the site to Frontend v6 just yet, as doing so will entail refactoring various bits of code which we don't have the time to do right now. 