### PR TITLE
Add sitemap title to Data>Examples

### DIFF
--- a/src/data/examples/index.md
+++ b/src/data/examples/index.md
@@ -1,6 +1,7 @@
 ---
 order: 4
 title: Examples
+sitemapTitle: Data examples
 ---
 
 These images show examples of GOV.UK-branded charts and visualisations.


### PR DESCRIPTION
Add sitemap title to Data>Examples as otherwise the sitemap link text is only a generic "Examples" that isn't clear without further context.