### PR TITLE
Ensure consistent ordering of navigation items

### DIFF
--- a/eleventy/navigation.js
+++ b/eleventy/navigation.js
@@ -45,7 +45,9 @@ export function setupNavigation(eleventyConfig) {
     // Last thing before we can use the `children` data is to make
     // sure it is sorted according to the `order` property
     for (const page of pages) {
-      page.data.children?.sort((a, b) => a.data.order - b.data.order)
+      page.data.children?.sort(
+        (a, b) => (a.data.order ?? Infinity) - (b.data.order ?? Infinity)
+      )
 
       page.data.ancestors = getAncestors(page)
 


### PR DESCRIPTION
Set an order of `Infinity` for items missing an `order` so that they don't break the ordering of the other items by skewing the comparison.

As `.sort` treats a `NaN` result as `0` (meaning the two items should stay in the same order), an `undefined` value for one of the pages' `order` doesn't lead to the correct sorting and we need to set a default value.