### PR TITLE
Remove phase banner from live

### DIFF
--- a/src/_layouts/_base.njk
+++ b/src/_layouts/_base.njk
@@ -47,13 +47,6 @@
         },
         html: 'This is a preview of <a class="govuk-link" href="https://github.com/alphagov/govuk-brand-guidelines/pull/' + site.env.REVIEW_ID + '">a proposed change</a> to the brand guidelines.'
       }) }}
-      {%- elif site.env.CONTEXT === "production" %}
-      {{ govukPhaseBanner({
-        tag: {
-          text: "Alpha"
-        },
-        text: "This is a new service. Help us improve it by giving your feedback."
-      }) }}
     {%- endif %}
 {% endblock %}
 


### PR DESCRIPTION
This is removing the phase banner from live as this is not a service and not asking for feedback.
It still keeps the banner for PRs and the local dev environment.