### PR TITLE
Updating 'Using the Brand'

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -43,8 +43,6 @@ Help users find, understand and trust the GOV.UK brand. Meet their needs across 
 
 These guidelines show government teams how to apply the brand on official GOV.UK channels.
 
-Teams in wider government also publish information and services as part of [the GOV.UK proposition](https://www.gov.uk/government/publications/govuk-proposition), with support from GDS. If you’re not part of GDS, you must get approval to apply the GOV.UK brand.
-
 {% endgridCell %}
 {% endgrid %}
 


### PR DESCRIPTION
Removing text from 'Using the Brand' section as per latest guidance from SLT that teams in government do not need approval to apply the branding to GOV.UK channels and services